### PR TITLE
Add IImportFormat as empty interface

### DIFF
--- a/src/PiWeb.Import.Sdk/IPluginContext.cs
+++ b/src/PiWeb.Import.Sdk/IPluginContext.cs
@@ -13,6 +13,7 @@ namespace Zeiss.PiWeb.Import.Sdk;
 using Environment;
 using Logging;
 using Modules.ImportAutomation;
+using Modules.ImportFormat;
 
 /// <summary>
 /// Represents the context of a plugin provided by the hosting application.
@@ -25,7 +26,7 @@ public interface IPluginContext
 	/// Contains information about the environment a plugin is hosted in.
 	/// </summary>
 	IEnvironmentInfo EnvironmentInfo { get; }
-
+    
 	/// <summary>
 	/// A logger that can be used to write log entries. Written entries are usually forwarded to the log file of the hosting application.
 	/// </summary>
@@ -38,6 +39,14 @@ public interface IPluginContext
 	/// <param name="importAutomation">The import automation to register.</param>
 	/// <exception cref="ModuleRegistrationException">Thrown when the import automation cannot be registered.</exception>
 	void RegisterImportAutomation( string id, IImportAutomation importAutomation );
+
+	/// <summary>
+	/// Registers an import format.
+	/// </summary>
+	/// <param name="id">The id of the import format.</param>
+	/// <param name="importFormat">The import format to register.</param>
+	/// <exception cref="ModuleRegistrationException">Thrown when the import format cannot be registered.</exception>
+	void RegisterImportFormat(string id, IImportFormat importFormat);
 
 	#endregion
 }

--- a/src/PiWeb.Import.Sdk/Modules/ImportFormat/IImportFormat.cs
+++ b/src/PiWeb.Import.Sdk/Modules/ImportFormat/IImportFormat.cs
@@ -1,0 +1,8 @@
+﻿namespace Zeiss.PiWeb.Import.Sdk.Modules.ImportFormat;
+
+/// <summary>
+/// Represents a custom import format provided as part of a plugin. Custom import formats provide a way to identify the relevant files,
+/// parse the data in those files and upload the data to PiWeb Server.
+/// </summary>
+public interface IImportFormat
+{ }


### PR DESCRIPTION
There is a new empty interface `IImportFormat `that can be registered at the `PluginContext `using `TryGetImportFormat`.

Associated with https://iqs-jira.zeiss.org/browse/PIWEB-19626