### PR TITLE
Extend IImportFormat to participate in grouping

### DIFF
--- a/src/PiWeb.Import.Sdk/Modules/ImportFormat/FileSourceExtensions.cs
+++ b/src/PiWeb.Import.Sdk/Modules/ImportFormat/FileSourceExtensions.cs
@@ -1,0 +1,77 @@
+﻿#region copyright
+
+/* * * * * * * * * * * * * * * * * * * * * * * * * */
+/* Carl Zeiss Industrielle Messtechnik GmbH        */
+/* Softwaresystem PiWeb                            */
+/* (c) Carl Zeiss 2024                             */
+/* * * * * * * * * * * * * * * * * * * * * * * * * */
+
+#endregion
+
+namespace Zeiss.PiWeb.Import.Sdk.Modules.ImportFormat;
+
+#region usings
+
+using System;
+using System.Collections.Generic;
+using System.Linq;
+
+#endregion
+
+/// <summary>
+/// Provides methods to work with <see cref="IFileSource"/> more easily.
+/// </summary>
+public static class FileSourceExtensions
+{
+    #region methods
+
+    /// <summary>
+    /// Checks if <paramref name="fileSource"/> has the requested file extension <paramref name="extension"/>.
+    /// </summary>
+    /// <param name="fileSource">The <see cref="IFileSource"/> to check.</param>
+    /// <param name="extension">The file extension (including the period ".").</param>
+    /// <returns><c>true</c> if the file has the extension; otherwise <c>false</c>.</returns>
+    public static bool HasExtension(this IFileSource fileSource, string extension)
+    {
+        if (!extension.StartsWith('.'))
+            extension = '.' + extension;
+
+        return fileSource.Name.EndsWith(extension, StringComparison.OrdinalIgnoreCase);
+    }
+
+    /// <summary>
+    /// Checks if <paramref name="fileSource"/> has any of the requested file extension <paramref name="extension"/>.
+    /// </summary>
+    /// <param name="fileSource">The <see cref="IFileSource"/> to check.</param>
+    /// <param name="extension">The file extensions (including the period ".").</param>
+    /// <returns><c>true</c> if the file has any of  the extensions; otherwise <c>false</c>.</returns>
+    public static bool HasAnyExtension(this IFileSource fileSource, IEnumerable<string> extension)
+    {
+        return extension.Any(f => f.Equals(fileSource.Extension, StringComparison.OrdinalIgnoreCase));
+    }
+
+    /// <summary>
+    /// Gets the first <see cref="IFileSource"/> within <paramref name="fileSources"/> that has any of the requested file extension in
+    /// <paramref name="extensions"/>.
+    /// </summary>
+    /// <param name="fileSources">The <see cref="IFileSource"/>s to check.</param>
+    /// <param name="extensions">The file extensions (including the period ".").</param>
+    /// <returns>The first matching <see cref="IFileSource"/>; otherwise <c>null</c>.</returns>
+    public static IFileSource? GetFirstWithExtension(this IEnumerable<IFileSource> fileSources, ISet<string> extensions)
+    {
+        return fileSources.FirstOrDefault(fileSource => fileSource.HasAnyExtension(extensions));
+    }
+
+    /// <summary>
+    /// Gets the first <see cref="IFileSource"/> within <paramref name="fileSources"/> that has the requested <paramref name="extensions"/>.
+    /// </summary>
+    /// <param name="fileSources">The <see cref="IFileSource"/>s to check.</param>
+    /// <param name="extensions">The file extension (including the period ".").</param>
+    /// <returns>The first matching <see cref="IFileSource"/>; otherwise <c>null</c>.</returns>
+    public static IFileSource? GetFirstWithExtension(this IEnumerable<IFileSource> fileSources, string extensions)
+    {
+        return fileSources.FirstOrDefault(fileSource => fileSource.HasExtension(extensions));
+    }
+
+    #endregion
+}

--- a/src/PiWeb.Import.Sdk/Modules/ImportFormat/IFileSource.cs
+++ b/src/PiWeb.Import.Sdk/Modules/ImportFormat/IFileSource.cs
@@ -1,0 +1,76 @@
+﻿#region copyright
+
+/* * * * * * * * * * * * * * * * * * * * * * * * * */
+/* Carl Zeiss Industrielle Messtechnik GmbH        */
+/* Softwaresystem PiWeb                            */
+/* (c) Carl Zeiss 2024                             */
+/* * * * * * * * * * * * * * * * * * * * * * * * * */
+
+#endregion
+
+namespace Zeiss.PiWeb.Import.Sdk.Modules.ImportFormat;
+
+#region usings
+
+using System.Diagnostics.CodeAnalysis;
+using System.IO;
+
+#endregion
+
+/// <summary>
+/// Represents a file.
+/// </summary>
+public interface IFileSource
+{
+    #region properties
+
+    /// <summary>
+    /// Gets the complete file name (including the extension) of this file.
+    /// </summary>
+    public string Name { get; }
+
+    /// <summary>
+    /// Gets the file name (without extension) of this file.
+    /// </summary>
+    public string BaseName { get; }
+
+    /// <summary>
+    /// Gets the file extension (including the period ".") of this file.
+    /// </summary>
+    /// <remarks>
+    /// This method obtains the extension of path by searching path for a period ("."), starting from the last character in
+    /// <see cref="Name"/> and continuing toward its first character. If a period is found before a directory separator, the returned
+    /// string contains the period and the characters after it; otherwise, <c>string.Empty</c> is returned.
+    /// </remarks>
+    public string Extension { get; }
+
+    /// <summary>
+    /// Gets the relative path of this file. This path is relative to the corresponding import folder.
+    /// </summary>
+    public string RelativePath { get; }
+
+    #endregion
+
+    #region methods
+
+    /// <summary>
+    /// Indicates whether the file exists.
+    /// </summary>
+    public bool Exists();
+
+    /// <summary>
+    /// Tries to get the file data as <see cref="Stream"/>.
+    /// </summary>
+    /// <param name="dataStream">The file stream.</param>
+    /// <returns><c>true</c> when the file could be read; otherwise <c>false</c>.</returns>
+    bool TryGetDataStream([NotNullWhen(true)] out Stream? dataStream);
+
+    /// <summary>
+    /// Tries to get the file data as byte array.
+    /// </summary>
+    /// <param name="data">The file content as byte array.</param>
+    /// <returns><c>true</c> when the file could be read; otherwise <c>false</c>.</returns>
+    bool TryGetData([NotNullWhen(true)] out byte[]? data);
+
+    #endregion
+}

--- a/src/PiWeb.Import.Sdk/Modules/ImportFormat/IGroupContext.cs
+++ b/src/PiWeb.Import.Sdk/Modules/ImportFormat/IGroupContext.cs
@@ -1,0 +1,48 @@
+﻿#region copyright
+
+/* * * * * * * * * * * * * * * * * * * * * * * * * */
+/* Carl Zeiss Industrielle Messtechnik GmbH        */
+/* Softwaresystem PiWeb                            */
+/* (c) Carl Zeiss 2024                             */
+/* * * * * * * * * * * * * * * * * * * * * * * * * */
+
+#endregion
+
+namespace Zeiss.PiWeb.Import.Sdk.Modules.ImportFormat;
+
+#region usings
+
+using System.Collections.Generic;
+
+#endregion
+
+/// <summary>
+/// Holds contextual information that might be required during the grouping of files for the import.
+/// </summary>
+public interface IGroupContext
+{
+    #region properties
+
+    /// <summary>
+    /// The list of available files that have not been associated with any import format yet.
+    /// </summary>
+    /// <remarks>
+    /// This list does not contain the primary file source that is a parameter of <see cref="IImportFormat.BuildGroup"/>.
+    /// </remarks>
+    IEnumerable<IFileSource> Files { get; }
+
+    #endregion
+
+    #region methods
+
+    /// <summary>
+    /// Gets all <see cref="IFileSource"/>s within <see cref="Files"/> that match the <paramref name="wildcardPattern"/>
+    /// and that are in the same folder as the primary file source (<see cref="IImportFormat.BuildGroup"/>).
+    /// </summary>
+    /// <remarks>Supports the following wildcards: '*' and '?'. It ignores the file casing.</remarks>
+    /// <param name="wildcardPattern">The wildcard pattern to match.</param>
+    /// <returns>All matching <see cref="IFileSource"/>s</returns>
+    IEnumerable<IFileSource> FindFilesLike(string wildcardPattern);
+
+    #endregion
+}

--- a/src/PiWeb.Import.Sdk/Modules/ImportFormat/IImportFormat.cs
+++ b/src/PiWeb.Import.Sdk/Modules/ImportFormat/IImportFormat.cs
@@ -1,8 +1,51 @@
 ﻿namespace Zeiss.PiWeb.Import.Sdk.Modules.ImportFormat;
 
+#region usings
+
+using System.Collections.Generic;
+
+#endregion
+
 /// <summary>
-/// Represents a custom import format provided as part of a plugin. Custom import formats provide a way to identify the relevant files,
-/// parse the data in those files and upload the data to PiWeb Server.
+/// Represents a custom import format provided as part of a plugin. Custom import formats provide a way to identify and group relevant
+/// files, parse their data and create a data image that can be uploaded to PiWeb Server.
 /// </summary>
 public interface IImportFormat
-{ }
+{
+    #region methods
+
+    /// <summary>
+    /// Builds an import group if the <see cref="IImportFormat"/> recognizes the <paramref name="primaryFileSource"/> and other
+    /// <see cref="IFileSource"/>s provided by the <paramref name="context"/>.
+    /// </summary>
+    /// <param name="primaryFileSource">The file to analyze and built a group of.</param>
+    /// <param name="context">Provides context information such as other files in the import folder.</param>
+    /// <returns>An <see cref="ImportGroup"/> defining the files identified; or <c>null</c> otherwise.</returns>
+    ImportGroup? BuildGroup(IFileSource primaryFileSource, IGroupContext context);
+
+    #endregion
+
+    #region properties
+
+    /// <summary>
+    /// The format identifier.
+    /// </summary>
+    string Identifier { get; }
+
+    /// <summary>
+    /// The short display name of the import format.
+    /// </summary>
+    string DisplayName { get; }
+
+    /// <summary>
+    /// The associated file extensions. The information is displayed in the import formats dialog.
+    /// </summary>
+    IReadOnlyCollection<string> StandardFileExtensions { get; }
+
+    /// <summary>
+    /// The display type of the import formats associated files. E.g. binary formats will not show a preview.
+    /// </summary>
+    SourceDisplayType SourceDisplay { get; }
+
+    #endregion
+}

--- a/src/PiWeb.Import.Sdk/Modules/ImportFormat/ImportGroup.cs
+++ b/src/PiWeb.Import.Sdk/Modules/ImportFormat/ImportGroup.cs
@@ -1,0 +1,37 @@
+﻿#region copyright
+
+/* * * * * * * * * * * * * * * * * * * * * * * * * */
+/* Carl Zeiss Industrielle Messtechnik GmbH        */
+/* Softwaresystem PiWeb                            */
+/* (c) Carl Zeiss 2024                             */
+/* * * * * * * * * * * * * * * * * * * * * * * * * */
+
+#endregion
+
+namespace Zeiss.PiWeb.Import.Sdk.Modules.ImportFormat;
+
+#region usings
+
+using System.Collections.Immutable;
+
+#endregion
+
+/// <summary>
+/// Represents a set of files that are imported as one group.
+/// </summary>
+public sealed record ImportGroup
+{
+    #region properties
+
+    /// <summary>
+    /// Gets the list of files in the import group. These files will not be considered by other import formats.
+    /// </summary>
+    public ImmutableList<IFileSource> Files { get; set; } = ImmutableList<IFileSource>.Empty;
+
+    /// <summary>
+    /// Describes the state of this <see cref="ImportGroup"/>.
+    /// </summary>
+    public State State { get; set; }
+
+    #endregion
+}

--- a/src/PiWeb.Import.Sdk/Modules/ImportFormat/ImportGroupExtensions.cs
+++ b/src/PiWeb.Import.Sdk/Modules/ImportFormat/ImportGroupExtensions.cs
@@ -1,0 +1,81 @@
+﻿#region copyright
+
+/* * * * * * * * * * * * * * * * * * * * * * * * * */
+/* Carl Zeiss Industrielle Messtechnik GmbH        */
+/* Softwaresystem PiWeb                            */
+/* (c) Carl Zeiss 2024                             */
+/* * * * * * * * * * * * * * * * * * * * * * * * * */
+
+#endregion
+
+namespace Zeiss.PiWeb.Import.Sdk.Modules.ImportFormat;
+
+#region usings
+
+using System.Collections.Generic;
+
+#endregion
+
+/// <summary>
+/// Provides extension methods for <see cref="ImportGroup"/>.
+/// </summary>
+public static class ImportGroupExtensions
+{
+    #region methods
+
+    /// <summary>
+    /// Creates an <see cref="ImportGroup"/> that is complete and can be imported at once.
+    /// </summary>
+    /// <param name="associatedFile">The file to be imported.</param>
+    public static ImportGroup CreateCompleteImportGroup(this IFileSource associatedFile)
+    {
+        var importGroup = new ImportGroup();
+        importGroup.Files = importGroup.Files.Add(associatedFile);
+        importGroup.State = State.Complete;
+
+        return importGroup;
+    }
+
+    /// <summary>
+    /// Creates an <see cref="ImportGroup"/> that is complete and can be imported at once.
+    /// </summary>
+    /// <param name="associatedFiles">The files to be imported together.</param>
+    public static ImportGroup CreateCompleteImportGroup(this IEnumerable<IFileSource> associatedFiles)
+    {
+        var importGroup = new ImportGroup();
+        importGroup.Files = importGroup.Files.AddRange(associatedFiles);
+        importGroup.State = State.Complete;
+
+        return importGroup;
+    }
+
+    /// <summary>
+    /// Creates an <see cref="ImportGroup"/> that is ready but misses some information. It can be imported when the missing information
+    /// does not appear after the designated waiting time.
+    /// </summary>
+    /// <param name="associatedFile">The file to be imported.</param>
+    public static ImportGroup CreateReadyImportGroup(this IFileSource associatedFile)
+    {
+        var importGroup = new ImportGroup();
+        importGroup.Files = importGroup.Files.Add(associatedFile);
+        importGroup.State = State.Ready;
+
+        return importGroup;
+    }
+
+    /// <summary>
+    /// Creates an <see cref="ImportGroup"/> that is ready but misses some information. It can be imported when the missing information
+    /// does not appear after the designated waiting time.
+    /// </summary>
+    /// <param name="associatedFiles">The files to be imported together.</param>
+    public static ImportGroup CreateReadyImportGroup(this IEnumerable<IFileSource> associatedFiles)
+    {
+        var importGroup = new ImportGroup();
+        importGroup.Files = importGroup.Files.AddRange(associatedFiles);
+        importGroup.State = State.Ready;
+
+        return importGroup;
+    }
+
+    #endregion
+}

--- a/src/PiWeb.Import.Sdk/Modules/ImportFormat/SourceDisplayType.cs
+++ b/src/PiWeb.Import.Sdk/Modules/ImportFormat/SourceDisplayType.cs
@@ -1,0 +1,27 @@
+﻿#region copyright
+
+/* * * * * * * * * * * * * * * * * * * * * * * * * */
+/* Carl Zeiss Industrielle Messtechnik GmbH        */
+/* Softwaresystem PiWeb                            */
+/* (c) Carl Zeiss 2024                             */
+/* * * * * * * * * * * * * * * * * * * * * * * * * */
+
+#endregion
+
+namespace Zeiss.PiWeb.Import.Sdk.Modules.ImportFormat;
+
+/// <summary>
+/// The file format of the data file(s) of an <see cref="IImportFormat"/>.
+/// </summary>
+public enum SourceDisplayType
+{
+    /// <summary>
+    /// This file will be shown as a text file in the configure import formats dialog.
+    /// </summary>
+    Text,
+
+    /// <summary>
+    /// This file will be handled as a binary file without preview in the configure import formats dialog.
+    /// </summary>
+    Binary
+}

--- a/src/PiWeb.Import.Sdk/Modules/ImportFormat/State.cs
+++ b/src/PiWeb.Import.Sdk/Modules/ImportFormat/State.cs
@@ -1,0 +1,30 @@
+﻿#region copyright
+
+/* * * * * * * * * * * * * * * * * * * * * * * * * */
+/* Carl Zeiss Industrielle Messtechnik GmbH        */
+/* Softwaresystem PiWeb                            */
+/* (c) Carl Zeiss 2024                             */
+/* * * * * * * * * * * * * * * * * * * * * * * * * */
+
+#endregion
+
+namespace Zeiss.PiWeb.Import.Sdk.Modules.ImportFormat;
+
+/// <summary>
+/// Defines the <see cref="ImportGroup"/>s state.
+/// </summary>
+public enum State
+{
+    /// <summary>
+    /// The import group is complete. No additional files will be added to this import group even if new files appear in the import source.
+    /// Completed import groups are usually imported immediately.
+    /// </summary>
+    Complete,
+
+    /// <summary>
+    /// The import group is ready. All files necessary for an import are present but additional files may still be added when new files
+    /// appear in the import source. Depending on configuration, ready import groups are usually only imported after a delay to make sure
+    /// no additional files show up.
+    /// </summary>
+    Ready
+}


### PR DESCRIPTION
Adds method `BuildGroup` to `IImportFormat` that is called by the AutoImporter when there are files in the import folder. The import format can define additional information about itself such as the supported file extensions and a description.