### PR TITLE
Remove import format identifier and display name

### DIFF
--- a/src/PiWeb.Import.Sdk/Modules/ImportFormat/IImportFormat.cs
+++ b/src/PiWeb.Import.Sdk/Modules/ImportFormat/IImportFormat.cs
@@ -38,16 +38,6 @@ public interface IImportFormat
     #region properties
 
     /// <summary>
-    /// The format identifier.
-    /// </summary>
-    string Identifier { get; }
-
-    /// <summary>
-    /// The short display name of the import format.
-    /// </summary>
-    string DisplayName { get; }
-
-    /// <summary>
     /// The associated file extensions. The information is displayed in the import formats dialog.
     /// </summary>
     IReadOnlyCollection<string> StandardFileExtensions { get; }


### PR DESCRIPTION
The display name is the import format title in the manifest. The identifier is built using other information from the manifest: [pluginId]+[formatId]