### PR TITLE
[PIWEB-20080] feat: Add configuration item picking an existing part

### DIFF
--- a/src/PiWeb.Import.Sdk/ConfigurationItems/PartSelectionConfigurationItem.cs
+++ b/src/PiWeb.Import.Sdk/ConfigurationItems/PartSelectionConfigurationItem.cs
@@ -1,0 +1,85 @@
+﻿#region copyright
+
+/* * * * * * * * * * * * * * * * * * * * * * * * * */
+/* Carl Zeiss Industrielle Messtechnik GmbH        */
+/* Softwaresystem PiWeb                            */
+/* (c) Carl Zeiss 2024                             */
+/* * * * * * * * * * * * * * * * * * * * * * * * * */
+
+#endregion
+
+namespace Zeiss.PiWeb.Import.Sdk.ConfigurationItems;
+
+using System;
+using PropertyStorage;
+
+/// <summary>
+/// Represents a configuration item for a property pointing to a specific part.
+/// </summary>
+public class PartSelectionConfigurationItem : ConfigurationItemBase
+{
+	#region members
+
+	private string _Value;
+
+	#endregion
+
+	#region constructors
+
+	/// <summary>
+	/// Initializes a new instance of the <see cref="PartSelectionConfigurationItem"/> class.
+	/// </summary>
+	/// <param name="defaultValue">The default value.</param>
+	public PartSelectionConfigurationItem( string defaultValue = "/" )
+	{
+		_Value = defaultValue;
+	}
+
+	/// <summary>
+	/// Initializes a new instance of the <see cref="PartSelectionConfigurationItem"/> class.
+	/// Associates this configuration item to a property of the given <paramref name="storage"/>.
+	/// </summary>
+	/// <param name="storage">The property storage to read from and write to.</param>
+	/// <param name="key">The key of the property to associate the configuration item with.</param>
+	/// <param name="defaultValue">The default value that is used if the property does not exist in the storage.</param>
+	public PartSelectionConfigurationItem( IPropertyStorage storage, string key, string defaultValue = "/" )
+	{
+		ArgumentNullException.ThrowIfNull( storage );
+		ArgumentNullException.ThrowIfNull( key );
+		ArgumentNullException.ThrowIfNull( defaultValue );
+
+		if( !storage.TryReadString( key, out var existingValue ) )
+		{
+			existingValue = defaultValue;
+			storage.WriteString( key, existingValue );
+		}
+		
+		_Value = existingValue;
+
+		storage.Changed += ( _, _ ) =>
+		{
+			Value = storage.ReadString( key, defaultValue );
+		};
+
+		PropertyChanged += ( _, e ) =>
+		{
+			if( e.PropertyName == nameof ( Value ) )
+				storage.WriteString( key, _Value );
+		};
+	}
+
+	#endregion
+
+	#region properties
+
+	/// <summary>
+	/// Gets or sets the path of the currently selected part of this configuration item.
+	/// </summary>
+	public string Value
+	{
+		get => _Value;
+		set => Set( ref _Value, value );
+	}
+
+	#endregion
+}


### PR DESCRIPTION
This PR adds a new _configuration item_ that can be used for selecting a single part in the connected inspection plan.

Visually it will look something like this:
![image](https://github.com/ZEISS-PiWeb/PiWeb-Import-Sdk/assets/43068830/5806fc20-26b5-4064-8511-d7c7564d9c1d)

Related Jira issue:
https://iqs-jira.zeiss.org/browse/PIWEB-20080