### PR TITLE
Move localization related methods to a common ILocalizationHandler interface

### DIFF
--- a/src/PiWeb.Import.Sdk/Activity/ActivityProperties.cs
+++ b/src/PiWeb.Import.Sdk/Activity/ActivityProperties.cs
@@ -21,14 +21,15 @@ public class ActivityProperties
 	public ActivityType ActivityType { get; init; } = ActivityType.Normal;
 
 	/// <summary>
-	/// The detailed text to display. This text is persisted and should be localized and formatted by implementing
-	/// <see cref="IPlugin.LocalizePersistedText"/> and/or <see cref="IPlugin.FormatPersistedText"/>.
+	/// The detailed text to display. A localization handler will be used to localize this text.
+	/// Implement <see cref="IPlugin.GetLocalizationHandler"/> to specify your own localization and formatting.
 	/// </summary>
 	public string DetailedDisplayText { get; init; } = string.Empty;
 
 	/// <summary>
-	/// The short text to display. This text is persisted and should be localized and formatted by implementing
-	/// <see cref="IPlugin.LocalizePersistedText"/> and/or <see cref="IPlugin.FormatPersistedText"/>.
+	/// The short text to display. A localization handler will be used to localize this text with the given
+	/// arguments. Implement <see cref="IPlugin.GetLocalizationHandler"/> to specify your own localization and
+	/// formatting.
 	/// </summary>
 	public string ShortDisplayText { get; init; } = string.Empty;
 

--- a/src/PiWeb.Import.Sdk/IPlugin.cs
+++ b/src/PiWeb.Import.Sdk/IPlugin.cs
@@ -10,8 +10,9 @@
 
 #region usings
 
-using System.Globalization;
+using System;
 using System.Threading.Tasks;
+using Zeiss.PiWeb.Import.Sdk.LocalizationHandler;
 
 #endregion
 
@@ -28,38 +29,25 @@ public interface IPlugin
     /// Initializes the plugin. Usually called during startup of the hosting application while showing a splash screen.
     /// Startup finishes when the returned task is completed.
     /// </summary>
-    /// <param name="context">Contains information about the hosting application.</param>
+    /// <param name="context">Contains information about the environment.</param>
     /// <exception cref="ModuleRegistrationException">Thrown when module registration fails.</exception>
     Task Init(IPluginContext context);
 
     /// <summary>
-    /// This method can be implemented to define a custom localization for persisted text. This allows persisted text
-    /// to be displayed in the current culture even if it was persisted in the context of another culture.
-    /// When this method returns <c>null</c>, the original text will be used without translation. This is also the
-    /// default implementation.
+    /// This method is called once to get a localization handler for the plugin. The handler is used internally
+    /// to localize messages and other text that is persisted. Methods that use this localization handler internally
+    /// are documented as such. When this method is not implemented, a default localization handler will be used.
+    /// Usually the default handler will not translate at all and use
+    /// <see cref="string.Format(IFormatProvider?, string, object[])"/>
+    /// to format. 
     /// </summary>
-    /// <param name="localizationCulture">Specifies the target language.</param>
-    /// <param name="text">The text or format string to translate.</param>
-    /// <returns>The localized text or <c>null</c> when the original text should be used.</returns>
-    string? LocalizePersistedText(CultureInfo localizationCulture, string text)
+    /// <param name="context">
+    /// Contains additional information for creating the <see cref="ILocalizationHandler"/> instance.
+    /// </param> 
+    /// <returns>The custom localization handler.</returns>
+    ILocalizationHandler GetLocalizationHandler(ILocalizationHandlerContext context)
     {
-        return null;
-    }
-
-    /// <summary>
-    /// This method can be implemented to define a custom formatting of format strings for persisted text. This method
-    /// is called after translation by <see cref="LocalizePersistedText"/> and can be used to format text after
-    /// translation.
-    /// When this method returns <c>null</c>, the built-in formatting is used which is equivalent to
-    /// <see cref="string.Format(System.IFormatProvider?,string,object?)"/>.
-    /// </summary>
-    /// <param name="formatCulture">The culture to use when formatting arguments.</param>
-    /// <param name="text">The localized format string.</param>
-    /// <param name="args">The arguments.</param>
-    /// <returns>The formatted text or <c>null</c> when the built-in formatting should be queried.</returns>
-    string? FormatPersistedText(CultureInfo formatCulture, string text, params object[] args)
-    {
-        return null;
+        return new FormatOnlyLocalizationHandler();
     }
 
     #endregion

--- a/src/PiWeb.Import.Sdk/LocalizationHandler/FormatOnlyLocalizationHandler.cs
+++ b/src/PiWeb.Import.Sdk/LocalizationHandler/FormatOnlyLocalizationHandler.cs
@@ -1,0 +1,29 @@
+#region copyright
+
+/* * * * * * * * * * * * * * * * * * * * * * * * * */
+/* Carl Zeiss Industrielle Messtechnik GmbH        */
+/* Softwaresystem PiWeb                            */
+/* (c) Carl Zeiss 2024                             */
+/* * * * * * * * * * * * * * * * * * * * * * * * * */
+
+#endregion
+
+using System;
+using System.Globalization;
+
+namespace Zeiss.PiWeb.Import.Sdk.LocalizationHandler;
+
+/// <summary>
+/// <inheritdoc />
+/// This implementation does not translate the input text at all and only applies
+/// <see cref="string.Format(IFormatProvider,string,object[])"/>
+/// formatting using the invariant culture. 
+/// </summary>
+public class FormatOnlyLocalizationHandler : ILocalizationHandler
+{
+    /// <inheritdoc />
+    public string LocalizeAndFormatText(string text, object[] args, ILocalizationContext context)
+    {
+        return string.Format(CultureInfo.InvariantCulture, text, args);
+    }
+}

--- a/src/PiWeb.Import.Sdk/LocalizationHandler/ILocalizationContext.cs
+++ b/src/PiWeb.Import.Sdk/LocalizationHandler/ILocalizationContext.cs
@@ -1,0 +1,47 @@
+#region copyright
+
+/* * * * * * * * * * * * * * * * * * * * * * * * * */
+/* Carl Zeiss Industrielle Messtechnik GmbH        */
+/* Softwaresystem PiWeb                            */
+/* (c) Carl Zeiss 2024                             */
+/* * * * * * * * * * * * * * * * * * * * * * * * * */
+
+#endregion
+
+#region usings
+
+using System.Globalization;
+using Zeiss.PiWeb.Import.Sdk.Logging;
+
+#endregion
+
+namespace Zeiss.PiWeb.Import.Sdk.LocalizationHandler;
+
+/// <summary>
+/// Represents the context of a localization call.
+/// </summary>
+public interface ILocalizationContext
+{
+    /// <summary>
+    /// Represents the target language of the translation.
+    /// </summary>
+    CultureInfo TranslationCulture { get; }
+
+    /// <summary>
+    /// Represents the format to use when formatting arguments.
+    /// </summary>
+    CultureInfo FormatCulture { get; }
+
+    /// <summary>
+    /// The version of the plugin that created the structured text to localize. For previously persisted
+    /// structured text (like automation activities or automation events), this will be the version of the plugin
+    /// that created the entries originally. 
+    /// </summary>
+    string OriginPluginVersion { get; }
+
+    /// <summary>
+    /// A logger that can be used to write log entries. Written entries are usually forwarded to the log file of the
+    /// hosting application.
+    /// </summary>
+    ILogger Logger { get; }
+}

--- a/src/PiWeb.Import.Sdk/LocalizationHandler/ILocalizationHandler.cs
+++ b/src/PiWeb.Import.Sdk/LocalizationHandler/ILocalizationHandler.cs
@@ -1,0 +1,37 @@
+#region copyright
+
+/* * * * * * * * * * * * * * * * * * * * * * * * * */
+/* Carl Zeiss Industrielle Messtechnik GmbH        */
+/* Softwaresystem PiWeb                            */
+/* (c) Carl Zeiss 2024                             */
+/* * * * * * * * * * * * * * * * * * * * * * * * * */
+
+#endregion
+
+using System;
+
+namespace Zeiss.PiWeb.Import.Sdk.LocalizationHandler;
+
+/// <summary>
+/// Responsible for localizing and formatting messages and other text. 
+/// </summary>
+public interface ILocalizationHandler
+{
+    /// <summary>
+    /// Localizes and formats the given format string and its parameters.
+    /// </summary>
+    /// <param name="text">The format string to localize.</param>
+    /// <param name="args">
+    /// The arguments of the format string to localize. Note that any arguments given for formatting which are not of
+    /// type int, double or DateTimeOffset are always transformed implicitely to string beforehand. 
+    /// </param>
+    /// <param name="context">
+    /// The context of the localization.
+    /// This context contains information about the translation target language.
+    /// </param>
+    /// <returns>
+    /// The localized and formatted text or null when no localization for the given parameters exists.
+    /// </returns>
+    /// <exception cref="FormatException">Thrown when formatting fails.</exception>
+    string? LocalizeAndFormatText(string text, object[] args, ILocalizationContext context);
+}

--- a/src/PiWeb.Import.Sdk/LocalizationHandler/ILocalizationHandlerContext.cs
+++ b/src/PiWeb.Import.Sdk/LocalizationHandler/ILocalizationHandlerContext.cs
@@ -1,0 +1,29 @@
+#region copyright
+
+/* * * * * * * * * * * * * * * * * * * * * * * * * */
+/* Carl Zeiss Industrielle Messtechnik GmbH        */
+/* Softwaresystem PiWeb                            */
+/* (c) Carl Zeiss 2024                             */
+/* * * * * * * * * * * * * * * * * * * * * * * * * */
+
+#endregion
+
+#region usings
+
+using Zeiss.PiWeb.Import.Sdk.Logging;
+
+#endregion
+
+namespace Zeiss.PiWeb.Import.Sdk.LocalizationHandler;
+
+/// <summary>
+/// Represents the context for creating an <see cref="ILocalizationHandler"/> instance.
+/// </summary>
+public interface ILocalizationHandlerContext
+{
+    /// <summary>
+    /// A logger that can be used to write log entries. Written entries are usually forwarded to the log file of the
+    /// hosting application.
+    /// </summary>
+    ILogger Logger { get; }
+}

--- a/src/PiWeb.Import.Sdk/Modules/ImportAutomation/IStatusService.cs
+++ b/src/PiWeb.Import.Sdk/Modules/ImportAutomation/IStatusService.cs
@@ -1,3 +1,13 @@
+#region copyright
+
+/* * * * * * * * * * * * * * * * * * * * * * * * * */
+/* Carl Zeiss Industrielle Messtechnik GmbH        */
+/* Softwaresystem PiWeb                            */
+/* (c) Carl Zeiss 2024                             */
+/* * * * * * * * * * * * * * * * * * * * * * * * * */
+
+#endregion
+
 using Zeiss.PiWeb.Import.Sdk.Activity;
 
 namespace Zeiss.PiWeb.Import.Sdk.Modules.ImportAutomation;
@@ -13,29 +23,35 @@ public interface IStatusService
     /// of the Auto Importer UI.
     /// </summary>
     /// <param name="displayText">
-    /// The display text of the event. This text is persisted and should be localized and formatted by implementing
-    /// <see cref="IPlugin.LocalizePersistedText"/> and/or <see cref="IPlugin.FormatPersistedText"/>.
+    /// The display text of the event. A localization handler will be used to localize this text with the given
+    /// arguments. Implement <see cref="IPlugin.GetLocalizationHandler"/> to specify your own localization and
+    /// formatting.
     /// </param>
     /// <param name="formatArgs">
-    /// Format arguments used to format the display text of the activity when this is a format string.
+    /// Format arguments used when formatting the display text of the activity.
     /// </param>
     /// <param name="severity">The severity of the event.</param>
     public void PostImportEvent( EventSeverity severity, string displayText, params object[] formatArgs );
 
     /// <summary>
-    /// Sets the current activity. The current activity of an import plan is shown at various places of the Auto Importer UI either as
-    /// detailed text or short text. Other properties of the current activity may also effect the display.
-    /// If this new activity has a different detailed text than the previous one, an import event with the same text is posted to document
-    /// the activity change. If the new activity is of suspension type, the event is posted as an error event.
+    /// Sets the current activity. The current activity of an import plan is shown at various places of the
+    /// Auto Importer UI either in the form of the detailed text or the short text. Other properties of the current
+    /// activity may also effect the display.
+    /// If this new activity has a different detailed text than the previous one, an import event with the same text
+    /// is posted to document the activity change. If the new activity is of suspension type, the event is posted as
+    /// an error event.
+    /// A localization handler will be used to localize the detailed text and the short text with the given format
+    /// arguments. Implement <see cref="IPlugin.GetLocalizationHandler"/> to specify your own localization and
+    /// formatting.
     /// </summary>
     /// <param name="activityProperties">The properties of the activity to show.</param>
     /// <param name="formatArgs">
-    /// Format arguments used to format detailed and short display text of the activity when these are format strings.
+    /// Format arguments used when formatting the detailed text and the short text of the activity.
     /// </param>
     public void SetActivity( ActivityProperties activityProperties, params object[] formatArgs );
 
     /// <summary>
-    /// Sets the current activity to no activity.
+    /// Resets the current activity to no activity.
     /// </summary>
     public void ClearActivity();
 }

--- a/src/PiWeb.Import.Sdk/Modules/ImportFormat/IImportHistoryService.cs
+++ b/src/PiWeb.Import.Sdk/Modules/ImportFormat/IImportHistoryService.cs
@@ -23,11 +23,12 @@ public interface IImportHistoryService
     /// Note: Adding messages with error severity leads to the import being canceled before any data is imported.
     /// </summary>
     /// <param name="displayText">
-    /// The display text of the message. This text is persisted and should be localized and formatted by implementing
-    /// <see cref="IPlugin.LocalizePersistedText"/> and/or <see cref="IPlugin.FormatPersistedText"/>.
+    /// The display text of the message. A localization handler will be used to localize this text with the given
+    /// arguments. Implement <see cref="IPlugin.GetLocalizationHandler"/> to specify your own localization and
+    /// formatting.
     /// </param>
     /// <param name="formatArgs">
-    /// Format arguments used to format the display text of the activity when this is a format string.
+    /// Format arguments used when formatting the display text of message.
     /// </param>
     /// <param name="severity">The severity of the message.</param>
     public void AddMessage(MessageSeverity severity, string displayText, params object[] formatArgs);


### PR DESCRIPTION
Move localization related methods to its own interface. This ensures the IPlugin interface is not a collection of random methods but a factory to create global objects like module instances or the localization handler instance.