### PR TITLE
refactor: Move RunState to the ImportAutomation namespace

### DIFF
--- a/src/PiWeb.Import.Sdk/Modules/ImportAutomation/ICreateAutomationConfigurationContext.cs
+++ b/src/PiWeb.Import.Sdk/Modules/ImportAutomation/ICreateAutomationConfigurationContext.cs
@@ -57,7 +57,7 @@ public interface ICreateAutomationConfigurationContext
 	ConnectionStatus ConnectionStatus { get; }
 
 	/// <summary>
-	/// The current run state of the associated runtime, e.g. Running.
+	/// The current run state of the associated runtime, e.g. Running or Stopped.
 	/// </summary>
 	RunState RunState { get; }
 

--- a/src/PiWeb.Import.Sdk/Modules/ImportAutomation/RunState.cs
+++ b/src/PiWeb.Import.Sdk/Modules/ImportAutomation/RunState.cs
@@ -8,7 +8,7 @@
 
 #endregion
 
-namespace Zeiss.PiWeb.Import.Sdk.ImportPlan;
+namespace Zeiss.PiWeb.Import.Sdk.Modules.ImportAutomation;
 
 /// <summary>
 /// Represents the different states an import plan runtime can be in.


### PR DESCRIPTION
The RunState is currently missplaced as it is not used to represent the inspection plan but to represent an automation runtime.