### PR TITLE
[PIWEB-20443] feat: Add MSBuild targets to easily create .pip file for project

### DIFF
--- a/src/PiWeb.Import.Sdk/PiWeb.Import.Sdk.csproj
+++ b/src/PiWeb.Import.Sdk/PiWeb.Import.Sdk.csproj
@@ -35,6 +35,7 @@
     <None Include="..\..\LICENSE.txt" Pack="true" PackagePath="\" />
     <None Include="..\..\readme.md" Pack="true" PackagePath="\" />
     <None Include="..\..\img\logo_128x128.png" Pack="true" PackagePath="\" />
+    <Content Include="build.targets" Pack="true" PackagePath="build/$(PackageId).targets" />
   </ItemGroup>
   
   <ItemGroup>

--- a/src/PiWeb.Import.Sdk/build.targets
+++ b/src/PiWeb.Import.Sdk/build.targets
@@ -1,0 +1,33 @@
+<Project xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+  
+  <PropertyGroup>
+    <!-- Whether to create a .pip package file when building -->
+    <GeneratePluginPackageOnBuild Condition=" '$(GeneratePluginPackageOnBuild)' == '' ">false</GeneratePluginPackageOnBuild>
+  </PropertyGroup>
+
+  <!-- Calls _GeneratePluginPackage after building when 'GeneratePluginPackageOnBuild' == true -->
+  <Target Name="PackPluginAfterBuild"
+          AfterTargets="Build"
+          Condition=" '$(GeneratePluginPackageOnBuild)' == 'true' "
+          DependsOnTargets="_GeneratePluginPackage">
+  </Target>
+
+  <!-- This target can be manually called to pack the project as .pip package file -->
+  <Target Name="PackPlugin" 
+          DependsOnTargets="_GeneratePluginPackage">
+  </Target>
+
+  <!-- Creates a .pip package file for the project -->
+  <Target Name="_GeneratePluginPackage" 
+          DependsOnTargets="Build">
+    
+    <ZipDirectory SourceDirectory="$(OutputPath)"
+                  DestinationFile="$(PackageOutputPath)\$(AssemblyName)@$(Version).pip"
+                  Overwrite="true" />
+    
+    <Message Text="Successfully created plugin package '$(PackageOutputPath)\$(AssemblyName)@$(Version).pip'."
+             Importance="high" />
+             
+  </Target>
+  
+</Project>


### PR DESCRIPTION
This PR adds MSBuild targets to the `PiWeb-Import-Sdk` NuGet to provide a simple way to create .pip files for a plugin project.

When the user defines `<GeneratePluginPackageOnBuild>true</GeneratePluginPackageOnBuild>` in the project, a .pip file will be automatically created each time the project is built.
_This is analogous to the `GeneratePackageOnBuild` property which automatically creates NuGet packages on build._

When the user invokes `dotnet build -t:PackPlugin <PathToProjectFile>` on the command line, a .pip file will be created in the output directory.
_This is analogous to invoking `dotnet pack <PathToProjectFile>` on the command line to manually create a NuGet package._

These features are available when a project references the `PiWeb-Import-Sdk` NuGet.

https://iqs-jira.zeiss.org/browse/PIWEB-20443