### PR TITLE
refactor: Add documentation for plugin examples

### DIFF
--- a/examples/FirstImportAutomation/ImportRunner.cs
+++ b/examples/FirstImportAutomation/ImportRunner.cs
@@ -24,14 +24,14 @@ namespace Zeiss.FirstImportAutomation;
 public class ImportRunner(ICreateImportRunnerContext context) : IImportRunner
 {
     /// <summary>
-    ///     Defined name for the part under which import is to take place.
+    /// Defined name for the part under which import is to take place.
     /// </summary>
     private const string TargetPartName = "FirstImportAutomationPart";
 
     /// <summary>
-    ///     IActivityService, retrieved by ICreateImportRunnerContext for later use.
+    /// IActivityService, retrieved by ICreateImportRunnerContext for later use.
     /// </summary>
-    private readonly IActivityService _statusService = context.ActivityService;
+    private readonly IActivityService _activityService = context.ActivityService;
 
     public async Task RunAsync(CancellationToken cancellationToken)
     {
@@ -63,7 +63,7 @@ public class ImportRunner(ICreateImportRunnerContext context) : IImportRunner
             while (!cancellationToken.IsCancellationRequested)
             {
                 // Inform user that the plug-in is currently active
-                _statusService.SetActivity(
+                _activityService.SetActivity(
                     new ActivityProperties()
                     {
                         ActivityType = ActivityType.Normal,
@@ -80,7 +80,7 @@ public class ImportRunner(ICreateImportRunnerContext context) : IImportRunner
                 {
                     // Part is known in database
 
-                    _statusService.SetActivity(
+                    _activityService.SetActivity(
                         new ActivityProperties()
                         {
                             ActivityType = ActivityType.Normal,
@@ -93,7 +93,7 @@ public class ImportRunner(ICreateImportRunnerContext context) : IImportRunner
                 {
                     // Part is unknown in database
 
-                    _statusService.SetActivity(
+                    _activityService.SetActivity(
                         new ActivityProperties()
                         {
                             ActivityType = ActivityType.Suspension,

--- a/examples/FirstImportAutomation/readme.txt
+++ b/examples/FirstImportAutomation/readme.txt
@@ -1,0 +1,12 @@
+This example demonstrates a simple import plug-in. The plug-in provides an import automation that can be
+selected as import source in an import plan of the PiWeb Auto Importer. Running this automation regularly checks
+whether a part named "FirstImportAutomationPart" exists in the PiWeb backend selected in the import plan. If it does
+not exist yet, it will be created. The plug-in demonstrates how to integrate the PiWeb API into an import automation.
+
+Since the manifest does not explicitly specify a main assembly, the main assembly of this plug-in must be named like
+the plug-in id given in the manifest. In this case, this will be "Zeiss.FirstImportAutomation.dll" which is the sole
+assembly of this plug-in.
+
+At application start the hosting application will load the main assembly and then it will try to find a class
+implementing IPlugin in this assembly. If such a class is found, it will be instantiated using its default constructor
+(which it must have). We implement the IPlugin interface in Plugin.cs. This makes it the entry point of the plug-in.

--- a/examples/SecondImportAutomation/readme.txt
+++ b/examples/SecondImportAutomation/readme.txt
@@ -1,0 +1,13 @@
+This example demonstrates a somewhat more complex import plug-in. The plug-in provides an import automation that can be
+selected as import source in an import plan of the PiWeb Auto Importer. Running this automation fetches current weather
+data in a given interval from a public whether data API and uploads these data to the PiWeb backend configured in the
+import plan. The plug-in demonstrates how to integrate the PiWeb API into an import automation and how to provide custom
+configuration items for the import plan.
+
+Since the manifest does not explicitly specify a main assembly, the main assembly of this plug-in must be named like
+the plug-in id given in the manifest. In this case, this will be "Zeiss.SecondImportAutomation.dll" which is the sole
+assembly of this plug-in.
+
+At application start the hosting application will load the main assembly and then it will try to find a class
+implementing IPlugin in this assembly. If such a class is found, it will be instantiated using its default constructor
+(which it must have). We implement the IPlugin interface in Plugin.cs. This makes it the entry point of the plug-in.

--- a/examples/StartingAPlugin/ImportAutomation.cs
+++ b/examples/StartingAPlugin/ImportAutomation.cs
@@ -14,8 +14,20 @@ namespace Zeiss.StartingAPlugin;
 
 public class ImportAutomation : IImportAutomation
 {
+    // An IImportAutomation instance usually is little more than a general factory for the different objects
+    // required by the hosting application. While there will normally be only one instance of ImportAutomation during
+    // application lifetime, multiple instances of IImportRunner and IAutomationConfiguration may be created and later
+    // disposed.
+
     public IImportRunner CreateImportRunner(ICreateImportRunnerContext context)
     {
+        // This method is called by the hosting application whenever an import plan (configured to use this automation)
+        // is started. We simply create an instance of our own IImportRunner implementation.
+        // This returned runner will be started by the hosting application shortly afterward.
+
         return new ImportRunner(context);
     }
+
+    // We could implement CreateConfiguration() here to provide custom entries in the import plan configuration UI
+    // but this plug-in does not need any custom configuration.
 }

--- a/examples/StartingAPlugin/ImportRunner.cs
+++ b/examples/StartingAPlugin/ImportRunner.cs
@@ -17,15 +17,28 @@ namespace Zeiss.StartingAPlugin;
 
 public sealed class ImportRunner(ICreateImportRunnerContext context) : IImportRunner
 {
-    private readonly IActivityService _statusService = context.ActivityService;
+    private readonly IActivityService _activityService = context.ActivityService;
 
     public async Task RunAsync(CancellationToken cancellationToken)
     {
+        // This run method is called after an import plan is started. It runs on a thread pool thread in the background
+        // and is not supposed to return until the cancellation is triggered via the given cancellation token.
+
+        // The properties of the context variable can be used to interact with the host application. It also
+        // provides the necessary location and authentication information to connect to the PiWeb backend configured by
+        // the user in the import plan.
+
+        // Usually we would do our custom data fetching and uploading in this method. However, since this is only a
+        // demonstration plug-in, we do not do any data processing or upload at all here.
+
         try
         {
             await Task.Delay(TimeSpan.FromSeconds(5), cancellationToken).ConfigureAwait(false);
 
-            _statusService.SetActivity(
+            // The activity service can be used to alter the currently displayed activity in the hosting application.
+            // We used this here to alter the current activity display after certain time intervals.
+
+            _activityService.SetActivity(
                 new ActivityProperties()
                 {
                     ActivityType = ActivityType.Normal,
@@ -36,11 +49,11 @@ public sealed class ImportRunner(ICreateImportRunnerContext context) : IImportRu
 
             await Task.Delay(TimeSpan.FromSeconds(5), cancellationToken).ConfigureAwait(false);
 
-            _statusService.ClearActivity();
+            _activityService.ClearActivity();
 
             await Task.Delay(TimeSpan.FromSeconds(5), cancellationToken).ConfigureAwait(false);
 
-            _statusService.SetActivity(
+            _activityService.SetActivity(
                 new ActivityProperties()
                 {
                     ActivityType = ActivityType.Normal,
@@ -50,7 +63,10 @@ public sealed class ImportRunner(ICreateImportRunnerContext context) : IImportRu
 
             await Task.Delay(TimeSpan.FromSeconds(5), cancellationToken).ConfigureAwait(false);
 
-            _statusService.SetActivity(
+            // Suspension activities can be set to inform the user about errors that prevent this automation from
+            // running as intended.
+
+            _activityService.SetActivity(
                 new ActivityProperties()
                 {
                     ActivityType = ActivityType.Suspension,
@@ -58,6 +74,9 @@ public sealed class ImportRunner(ICreateImportRunnerContext context) : IImportRu
                     DetailedDisplayText = "We triggered an error",
                     IsSourceProblem = true
                 });
+
+            // From here on we just wait indefinitely for the cancellation token to be triggered, and then we leave
+            // the run method.
 
             await Task.Delay(TimeSpan.FromMilliseconds(-1), cancellationToken).ConfigureAwait(false);
         }

--- a/examples/StartingAPlugin/Plugin.cs
+++ b/examples/StartingAPlugin/Plugin.cs
@@ -15,8 +15,18 @@ namespace Zeiss.StartingAPlugin;
 
 public class Plugin : IPlugin
 {
+    // This class is instantiated once when the hosting application loads its plug-ins. It must provide a default
+    // constructor. Like in this implementation, the default constructor can be implicit.
+
+    // Depending on the specified type in the 'provides' section of the manifest, either CreateImportAutomation()
+    // or CreateImportFormat() must be implemented. In this case the manifest specifies 'ImportAutomation' as type.
+
     public IImportAutomation CreateImportAutomation(ICreateImportAutomationContext context)
     {
+        // This method is called once when the hosting application is initializing its plug-ins. The purpose of this
+        // method is only to create a plug-in specific instance of IImportAutomation which implements all the plug-in
+        // logic.
+
         return new ImportAutomation();
     }
 }

--- a/examples/StartingAPlugin/readme.txt
+++ b/examples/StartingAPlugin/readme.txt
@@ -1,0 +1,11 @@
+This example demonstrates a very basic import plug-in. The plug-in provides an import automation that can be selected
+as import source in an import plan of the PiWeb Auto Importer. Running this automation does nothing except changing
+the displayed status of the import plan a few times and then waiting for the user to stop the import plan again.
+
+Since the manifest does not explicitly specify a main assembly, the main assembly of this plug-in must be named like
+the plug-in id given in the manifest. In this case, this will be "Zeiss.StartingAPlugin.dll" which is the sole assembly
+of this plug-in.
+
+At application start the hosting application will load the main assembly and then it will try to find a class
+implementing IPlugin in this assembly. If such a class is found, it will be instantiated using its default constructor
+(which it must have). We implement the IPlugin interface in Plugin.cs. This makes it the entry point of the plug-in.


### PR DESCRIPTION
I added some readme files to the example projects to make it easier to see where to start reading. I also added code comments to the StartingAPlugin example.