### PR TITLE
[PIWEB-20259] feat: Add project template for easy creation of new plugin projects

### DIFF
--- a/templates/Zeiss.PiWeb.Sdk.Import.ProjectTemplates.csproj
+++ b/templates/Zeiss.PiWeb.Sdk.Import.ProjectTemplates.csproj
@@ -1,0 +1,32 @@
+<Project Sdk="Microsoft.NET.Sdk">
+
+  <PropertyGroup>
+    <PackageType>Template</PackageType>
+    <TargetFramework>netstandard2.0</TargetFramework>
+    <PackageId>Zeiss.PiWeb.Sdk.Import.ProjectTemplates</PackageId>
+    <Title>PiWeb-Import-Sdk Project Templates</Title>
+    <Company>Carl Zeiss Industrielle Messtechnik GmbH</Company>
+    <Authors>$(Company)</Authors>
+    <Copyright>Copyright © $([System.DateTime]::UtcNow.Year) $(Company)</Copyright>
+    <Description>Project templates for creating new plugins for the PiWeb-Import-Sdk.</Description>
+    <PackageTags>dotnet-new;templates;zeiss;piweb;auto importer;plugin;import;sdk</PackageTags>
+    <PackageIcon>logo_128x128.png</PackageIcon>
+    <PackageLicenseFile>LICENSE.txt</PackageLicenseFile>
+    <PackageProjectUrl>https://github.com/ZEISS-PiWeb/PiWeb-Import-Sdk</PackageProjectUrl>
+    <RepositoryUrl>https://github.com/ZEISS-PiWeb/PiWeb-Import-Sdk.git</RepositoryUrl>
+    <RepositoryType>git</RepositoryType>
+    <PackageOutputPath>$(MSBuildThisFileDirectory)\</PackageOutputPath>
+    <IncludeContentInPack>true</IncludeContentInPack>
+    <IncludeBuildOutput>false</IncludeBuildOutput>
+    <ContentTargetFolders>content</ContentTargetFolders>
+    <SuppressDependenciesWhenPacking>true</SuppressDependenciesWhenPacking>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <Content Include="content\**" PackagePath="content" Exclude="content\**\bin\**;content\**\obj\**" />
+    <None Include="..\img\logo_128x128.png" Pack="true" PackagePath="\" />
+    <None Include="..\LICENSE.txt" Pack="true" PackagePath="\" />
+    <Compile Remove="**\*" />
+  </ItemGroup>
+
+</Project>

--- a/templates/content/Zeiss.PiWeb.Sdk.Import.PluginProject/.template.config/template.json
+++ b/templates/content/Zeiss.PiWeb.Sdk.Import.PluginProject/.template.config/template.json
@@ -1,0 +1,65 @@
+{
+  "$schema": "http://json.schemastore.org/template",
+  "author": "Zeiss",
+  "classifications": [ "Zeiss", "PiWeb", "Auto Importer" ], 
+  "name": "PiWeb-Import-Sdk Plugin",
+  "description": "Project for creating a new plugin for the PiWeb-Import-Sdk",
+  "identity": "Zeiss.PiWeb.Sdk.Import.PluginProject",
+  "shortName": "piweb-import-plugin",
+  "tags": {
+    "language": "C#",
+    "type": "project"
+  },
+  "sourceName": "Zeiss.PiWeb.Sdk.Import.PluginProject",
+  "preferNameDirectory" : true,
+  "symbols":{
+    "PluginType": {
+      "type": "parameter",
+      "datatype": "choice",
+      "description": "The type of plugin.",
+      "displayName": "Plugin type",
+      "defaultValue": "importFormat",
+      "choices": [
+        {
+          "choice": "ImportFormat",
+          "displayName": "Import format",
+          "description": "Create import format plugin"
+        },
+        {
+          "choice": "ImportAutomation",
+          "displayName": "Import automation",
+          "description": "Create import automation plugin"
+        }
+      ]
+    },
+    "UseFormatModule": {
+      "type": "computed",
+      "value": "(PluginType == \"ImportFormat\")"
+    },
+    "UseAutomationModule": {
+      "type": "computed",
+      "value": "(PluginType == \"ImportAutomation\")"
+    }
+  },
+  "sources": [
+    {
+      "modifiers": [
+        {
+          "condition": "UseFormatModule",
+          "exclude": [
+            "ImportAutomation.cs",
+            "ImportRunner.cs",
+            "AutomationConfiguration.cs"
+          ]
+        },
+        {
+          "condition": "UseAutomationModule",
+          "exclude": [
+            "ImportFormat.cs",
+            "ImportParser.cs"
+          ]
+        }
+      ]
+    }
+  ]
+}

--- a/templates/content/Zeiss.PiWeb.Sdk.Import.PluginProject/AutomationConfiguration.cs
+++ b/templates/content/Zeiss.PiWeb.Sdk.Import.PluginProject/AutomationConfiguration.cs
@@ -1,0 +1,9 @@
+﻿using Zeiss.PiWeb.Sdk.Import.Modules.ImportAutomation;
+
+namespace Zeiss.PiWeb.Sdk.Import.PluginProject;
+
+public class AutomationConfiguration : IAutomationConfiguration
+{
+    public AutomationConfiguration(ICreateAutomationConfigurationContext context)
+    { }
+}

--- a/templates/content/Zeiss.PiWeb.Sdk.Import.PluginProject/ImportAutomation.cs
+++ b/templates/content/Zeiss.PiWeb.Sdk.Import.PluginProject/ImportAutomation.cs
@@ -1,0 +1,16 @@
+using Zeiss.PiWeb.Sdk.Import.Modules.ImportAutomation;
+
+namespace Zeiss.PiWeb.Sdk.Import.PluginProject;
+
+public class ImportAutomation : IImportAutomation
+{
+    public IImportRunner CreateImportRunner(ICreateImportRunnerContext context)
+    {
+        return new ImportRunner(context);
+    }
+
+    public IAutomationConfiguration CreateConfiguration(ICreateAutomationConfigurationContext context)
+    {
+        return new AutomationConfiguration(context);
+    }
+}

--- a/templates/content/Zeiss.PiWeb.Sdk.Import.PluginProject/ImportFormat.cs
+++ b/templates/content/Zeiss.PiWeb.Sdk.Import.PluginProject/ImportFormat.cs
@@ -1,0 +1,17 @@
+using Zeiss.PiWeb.Sdk.Import.ImportFiles;
+using Zeiss.PiWeb.Sdk.Import.Modules.ImportFormat;
+
+namespace Zeiss.PiWeb.Sdk.Import.PluginProject;
+
+public class ImportFormat : IImportFormat
+{
+    public IImportGroupFilter CreateImportGroupFilter(ICreateImportGroupFilterContext context)
+    {
+        return new FileExtensionImportGroupFilter(".xyz");
+    }
+
+    public IImportParser CreateImportParser(ICreateImportParserContext context)
+    {
+        return new ImportParser();
+    }
+}

--- a/templates/content/Zeiss.PiWeb.Sdk.Import.PluginProject/ImportParser.cs
+++ b/templates/content/Zeiss.PiWeb.Sdk.Import.PluginProject/ImportParser.cs
@@ -1,0 +1,22 @@
+using System.Threading;
+using System.Threading.Tasks;
+using Zeiss.PiWeb.Sdk.Import.ImportData;
+using Zeiss.PiWeb.Sdk.Import.ImportFiles;
+using Zeiss.PiWeb.Sdk.Import.Modules.ImportFormat;
+
+namespace Zeiss.PiWeb.Sdk.Import.PluginProject;
+
+public class ImportParser : IImportParser
+{
+    public async Task<ImportData> ParseAsync(
+        IImportGroup importGroup,
+        IParseContext context,
+        CancellationToken cancellationToken = default)
+    {
+        var root = new InspectionPlanPart("root");
+
+        await Task.Delay(100, cancellationToken);
+
+        return new ImportData(root);
+    }
+}

--- a/templates/content/Zeiss.PiWeb.Sdk.Import.PluginProject/ImportRunner.cs
+++ b/templates/content/Zeiss.PiWeb.Sdk.Import.PluginProject/ImportRunner.cs
@@ -1,0 +1,38 @@
+using System;
+using System.Threading;
+using System.Threading.Tasks;
+using Zeiss.PiWeb.Sdk.Import.Modules.ImportAutomation;
+
+namespace Zeiss.PiWeb.Sdk.Import.PluginProject;
+
+public class ImportRunner : IImportRunner
+{
+    private readonly ICreateImportRunnerContext _Context;
+
+    public ImportRunner(ICreateImportRunnerContext context)
+    {
+        _Context = context;
+    }
+
+    public async Task RunAsync(CancellationToken cancellationToken)
+    {
+        try
+        {
+            while (!cancellationToken.IsCancellationRequested)
+            {
+                // import loop
+                await Task.Delay( TimeSpan.FromSeconds( 1 ), cancellationToken );
+            }
+        }
+        catch (OperationCanceledException)
+        {
+            // Do nothing
+        }
+    }
+
+    public ValueTask DisposeAsync()
+    {
+        // Nothing to dispose
+        return ValueTask.CompletedTask;
+    }
+}

--- a/templates/content/Zeiss.PiWeb.Sdk.Import.PluginProject/Plugin.cs
+++ b/templates/content/Zeiss.PiWeb.Sdk.Import.PluginProject/Plugin.cs
@@ -1,0 +1,25 @@
+﻿using Zeiss.PiWeb.Sdk.Import;
+#if (UseAutomationModule)
+using Zeiss.PiWeb.Sdk.Import.Modules.ImportAutomation;
+#endif
+#if (UseFormatModule)
+using Zeiss.PiWeb.Sdk.Import.Modules.ImportFormat;
+#endif
+
+namespace Zeiss.PiWeb.Sdk.Import.PluginProject;
+
+public class Plugin : IPlugin
+{
+#if (UseAutomationModule)
+    public IImportAutomation CreateImportAutomation(ICreateImportAutomationContext context)
+    {
+        return new ImportAutomation();
+    }
+#endif
+#if (UseFormatModule)
+    public IImportFormat CreateImportFormat(ICreateImportFormatContext context)
+    {
+        return new ImportFormat();
+    }
+#endif
+}

--- a/templates/content/Zeiss.PiWeb.Sdk.Import.PluginProject/Properties/launchSettings.json
+++ b/templates/content/Zeiss.PiWeb.Sdk.Import.PluginProject/Properties/launchSettings.json
@@ -1,0 +1,10 @@
+{
+  "profiles": {
+    "AutoImporter": {
+      "commandName": "Executable",
+      "workingDirectory": "$(ProjectDir)",
+      "executablePath": "%ProgramFiles%\\Zeiss\\PiWeb\\AutoImporter.exe",
+      "commandLineArgs": "-pluginSearchPaths $(OutDir)"
+    }
+  }
+}

--- a/templates/content/Zeiss.PiWeb.Sdk.Import.PluginProject/Zeiss.PiWeb.Sdk.Import.PluginProject.csproj
+++ b/templates/content/Zeiss.PiWeb.Sdk.Import.PluginProject/Zeiss.PiWeb.Sdk.Import.PluginProject.csproj
@@ -1,0 +1,18 @@
+﻿<Project Sdk="Microsoft.NET.Sdk">
+
+  <PropertyGroup>
+    <TargetFramework>net8.0</TargetFramework>
+    <Nullable>enable</Nullable>
+    <EnableDynamicLoading>true</EnableDynamicLoading>
+    <GeneratePluginPackageOnBuild>true</GeneratePluginPackageOnBuild>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <PackageReference Include="Zeiss.PiWeb.Sdk.Import" Version="1.0.0" Private="false" ExcludeAssets="runtime" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <None Update="manifest.json" CopyToOutputDirectory="PreserveNewest" />
+  </ItemGroup>
+
+</Project>

--- a/templates/content/Zeiss.PiWeb.Sdk.Import.PluginProject/manifest.json
+++ b/templates/content/Zeiss.PiWeb.Sdk.Import.PluginProject/manifest.json
@@ -1,0 +1,21 @@
+{
+  "$schema": "https://raw.github.com/ZEISS-PiWeb/PiWeb-Import-Sdk/refs/heads/pub/schemas/manifest-schema.json",
+  "id": "Zeiss.PiWeb.Sdk.Import.PluginProject",
+  "version": "1.0.0",
+  "title": "Zeiss.PiWeb.Sdk.Import.PluginProject",
+  "description": "TODO: Add description for Zeiss.PiWeb.Sdk.Import.PluginProject",
+
+  //#if (UseAutomationModule)
+  "provides": {
+    "type": "ImportAutomation",
+    "displayName": "Zeiss.PiWeb.Sdk.Import.PluginProject import automation",
+    "summary": "TODO: Add summary for import automation"
+  }
+  //#endif
+  //#if (UseFormatModule)
+  "provides": {
+    "type": "ImportFormat",
+    "displayName": "Zeiss.PiWeb.Sdk.Import.PluginProject import format"
+  }
+  //#endif
+}


### PR DESCRIPTION
This PR adds a [.NET project template](https://learn.microsoft.com/en-us/dotnet/core/tutorials/cli-templates-create-project-template) for easily creating new `PiWeb-Import-Sdk` projects.

Project templates are shared as usual NuGets usually via https://www.nuget.org/.

A new version of this project template NuGet can be created running the follwing in the _templates/_ folder:
`dotnet pack -p:Version=<YourVersion>`

The NuGet then needs to be published on https://www.nuget.org/.

The latest version of this project template can then be installed running the following:
`dotnet new install Zeiss.PiWeb.Sdk.Import.ProjectTemplates`

A preview version is available [here](https://www.nuget.org/packages/Zeiss.PiWeb.Sdk.Import.ProjectTemplates/1.0.0-alpha.6) and can already be installed running the command above.

## Usage in Rider
![image](https://github.com/user-attachments/assets/57415166-eec2-4ced-81f4-72008498dcba)

## Usage in Visual Studio
![1219_devenv_NELPg4vKVf](https://github.com/user-attachments/assets/86d5a6d9-fb77-41ca-83a7-7290ed0df344)

## Usage in command line
![image](https://github.com/user-attachments/assets/0c821976-c7e8-4e7e-bebd-862db07f1a71)

## The resulting project will look something like that:
![image](https://github.com/user-attachments/assets/6d673319-04f3-4c6b-9236-28cbcd8f0121)
