### PR TITLE
Add and adapt example plug-ins for documentation

### DIFF
--- a/examples/FirstImportAutomation/FirstImportAutomation.csproj
+++ b/examples/FirstImportAutomation/FirstImportAutomation.csproj
@@ -1,23 +1,22 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
-    <PropertyGroup>
-        <TargetFramework>net8.0</TargetFramework>
-        <Nullable>enable</Nullable>
-        <AssemblyName>Zeiss.FirstImportAutomation</AssemblyName>
-        <RootNamespace>Zeiss.FirstImportAutomation</RootNamespace>
-    </PropertyGroup>
+  <PropertyGroup>
+    <TargetFramework>net8.0</TargetFramework>
+    <Nullable>enable</Nullable>
+    <EnableDynamicLoading>true</EnableDynamicLoading>
+    <GeneratePluginPackageOnBuild>true</GeneratePluginPackageOnBuild>
+    <RootNamespace>Zeiss.FirstImportAutomation</RootNamespace>
+    <Authors>Carl Zeiss IMT GmbH</Authors>
+    <Company>Carl Zeiss IMT GmbH</Company>
+  </PropertyGroup>
 
-    <ItemGroup>
-        <None Update="manifest.json" CopyToOutputDirectory="PreserveNewest" />
-    </ItemGroup>
+  <ItemGroup>
+    <PackageReference Include="Zeiss.PiWeb.Sdk.Import" Version="1.0.0" Private="false" ExcludeAssets="runtime"/>
+    <PackageReference Include="Zeiss.PiWeb.Api.Rest" Version="9.0.0" />
+  </ItemGroup>
 
-    <ItemGroup>
-        <PackageReference Include="Zeiss.PiWeb.Sdk.Import" Version="1.0.0-beta0058-97">
-            <Private>false</Private>
-            <ExcludeAssets>runtime</ExcludeAssets>
-        </PackageReference>
-
-        <PackageReference Include="Zeiss.PiWeb.Api.Rest" Version="8.4.0-beta0004-137" />
-    </ItemGroup>
+  <ItemGroup>
+    <None Update="manifest.json" CopyToOutputDirectory="PreserveNewest"/>
+  </ItemGroup>
 
 </Project>

--- a/examples/FirstImportAutomation/Properties/launchSettings.json
+++ b/examples/FirstImportAutomation/Properties/launchSettings.json
@@ -2,8 +2,9 @@
     "profiles": {
         "AutoImporter": {
             "commandName": "Executable",
-            "executablePath": "C:\\Program Files\\Zeiss\\PiWeb\\AutoImporter.exe",
-            "commandLineArgs": "-pluginSearchPaths $(MSBuildThisFileDirectory)\\bin\\Debug -language en"
+            "workingDirectory": "$(ProjectDir)",
+            "executablePath": "%ProgramFiles%\\Zeiss\\PiWeb\\AutoImporter.exe",
+            "commandLineArgs": "-pluginSearchPaths $(OutDir)"
         }
     }
 }

--- a/examples/FirstImportFormat/FirstImportFormat.csproj
+++ b/examples/FirstImportFormat/FirstImportFormat.csproj
@@ -1,0 +1,26 @@
+﻿<Project Sdk="Microsoft.NET.Sdk">
+
+  <PropertyGroup>
+    <TargetFramework>net8.0</TargetFramework>
+    <Nullable>enable</Nullable>
+    <AssemblyName>SimpleTxtFormat</AssemblyName>
+    <RootNamespace>Zeiss.FirstImportFormat</RootNamespace>
+    <PackageId>Zeiss.FirstImportFormat</PackageId>
+    <Authors>Zeiss.FirstImportFormat</Authors>
+    <Company>Zeiss IMT GmbH</Company>
+    <Product>Zeiss.FirstImportFormat</Product>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <None Update="manifest.json" CopyToOutputDirectory="PreserveNewest"/>
+    <None Update="SampleData/**" CopyToOutputDirectory="PreserveNewest"/>
+  </ItemGroup>
+
+  <ItemGroup>
+    <PackageReference Include="Zeiss.PiWeb.Sdk.Import" Version="1.0.0-beta0058-97">
+      <Private>false</Private>
+      <ExcludeAssets>runtime</ExcludeAssets>
+    </PackageReference>
+  </ItemGroup>
+  
+</Project>

--- a/examples/FirstImportFormat/FirstImportFormat.csproj
+++ b/examples/FirstImportFormat/FirstImportFormat.csproj
@@ -3,24 +3,21 @@
   <PropertyGroup>
     <TargetFramework>net8.0</TargetFramework>
     <Nullable>enable</Nullable>
-    <AssemblyName>SimpleTxtFormat</AssemblyName>
+    <EnableDynamicLoading>true</EnableDynamicLoading>
+    <GeneratePluginPackageOnBuild>true</GeneratePluginPackageOnBuild>
     <RootNamespace>Zeiss.FirstImportFormat</RootNamespace>
-    <PackageId>Zeiss.FirstImportFormat</PackageId>
-    <Authors>Zeiss.FirstImportFormat</Authors>
-    <Company>Zeiss IMT GmbH</Company>
+    <Authors>Carl Zeiss IMT GmbH</Authors>
+    <Company>Carl Zeiss IMT GmbH</Company>
     <Product>Zeiss.FirstImportFormat</Product>
+    <PackageId>Zeiss.FirstImportFormat</PackageId>
   </PropertyGroup>
 
   <ItemGroup>
-    <None Update="manifest.json" CopyToOutputDirectory="PreserveNewest"/>
-    <None Update="SampleData/**" CopyToOutputDirectory="PreserveNewest"/>
+    <PackageReference Include="Zeiss.PiWeb.Sdk.Import" Version="1.0.0" Private="false" ExcludeAssets="runtime"/>
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="Zeiss.PiWeb.Sdk.Import" Version="1.0.0-beta0058-97">
-      <Private>false</Private>
-      <ExcludeAssets>runtime</ExcludeAssets>
-    </PackageReference>
+    <None Update="manifest.json" CopyToOutputDirectory="PreserveNewest"/>
   </ItemGroup>
-  
+
 </Project>

--- a/examples/FirstImportFormat/ImportFormat.cs
+++ b/examples/FirstImportFormat/ImportFormat.cs
@@ -8,12 +8,8 @@
 
 #endregion
 
-#region usings
-
 using Zeiss.PiWeb.Sdk.Import.ImportFiles;
 using Zeiss.PiWeb.Sdk.Import.Modules.ImportFormat;
-
-#endregion
 
 namespace Zeiss.FirstImportFormat;
 

--- a/examples/FirstImportFormat/ImportFormat.cs
+++ b/examples/FirstImportFormat/ImportFormat.cs
@@ -1,0 +1,31 @@
+﻿#region copyright
+
+/* * * * * * * * * * * * * * * * * * * * * * * * * */
+/* Carl Zeiss Industrielle Messtechnik GmbH        */
+/* Softwaresystem PiWeb                            */
+/* (c) Carl Zeiss 2024                             */
+/* * * * * * * * * * * * * * * * * * * * * * * * * */
+
+#endregion
+
+#region usings
+
+using Zeiss.PiWeb.Sdk.Import.ImportFiles;
+using Zeiss.PiWeb.Sdk.Import.Modules.ImportFormat;
+
+#endregion
+
+namespace Zeiss.FirstImportFormat;
+
+public sealed class ImportFormat : IImportFormat
+{
+    public IImportGroupFilter CreateImportGroupFilter(ICreateImportGroupFilterContext context)
+    {
+        return new SimpleTxtImportGroupFilter();
+    }
+
+    public IImportParser CreateImportParser(ICreateImportParserContext context)
+    {
+        return new SimpleTxtImportParser();
+    }
+}

--- a/examples/FirstImportFormat/Plugin.cs
+++ b/examples/FirstImportFormat/Plugin.cs
@@ -1,0 +1,27 @@
+﻿#region copyright
+
+/* * * * * * * * * * * * * * * * * * * * * * * * * */
+/* Carl Zeiss Industrielle Messtechnik GmbH        */
+/* Softwaresystem PiWeb                            */
+/* (c) Carl Zeiss 2024                             */
+/* * * * * * * * * * * * * * * * * * * * * * * * * */
+
+#endregion
+
+#region usings
+
+using Zeiss.PiWeb.Sdk.Import;
+using Zeiss.PiWeb.Sdk.Import.Modules.ImportFormat;
+
+#endregion
+
+namespace Zeiss.FirstImportFormat;
+
+public class Plugin : IPlugin
+{
+    /// <inheritdoc />
+    public IImportFormat CreateImportFormat(ICreateImportFormatContext context)
+    {
+        return new FirstImportFormat.ImportFormat();
+    }
+}

--- a/examples/FirstImportFormat/Plugin.cs
+++ b/examples/FirstImportFormat/Plugin.cs
@@ -8,12 +8,8 @@
 
 #endregion
 
-#region usings
-
 using Zeiss.PiWeb.Sdk.Import;
 using Zeiss.PiWeb.Sdk.Import.Modules.ImportFormat;
-
-#endregion
 
 namespace Zeiss.FirstImportFormat;
 

--- a/examples/FirstImportFormat/Properties/launchSettings.json
+++ b/examples/FirstImportFormat/Properties/launchSettings.json
@@ -4,7 +4,7 @@
             "commandName": "Executable",
             "workingDirectory": "$(ProjectDir)",
             "executablePath": "%ProgramFiles%\\Zeiss\\PiWeb\\AutoImporter.exe",
-            "commandLineArgs": "-pluginSearchPaths $(OutDir) -language en"
+            "commandLineArgs": "-pluginSearchPaths $(OutDir)"
         }
     }
 }

--- a/examples/FirstImportFormat/Properties/launchSettings.json
+++ b/examples/FirstImportFormat/Properties/launchSettings.json
@@ -1,0 +1,10 @@
+{
+    "profiles": {
+        "AutoImporter": {
+            "commandName": "Executable",
+            "workingDirectory": "$(ProjectDir)",
+            "executablePath": "%ProgramFiles%\\Zeiss\\PiWeb\\AutoImporter.exe",
+            "commandLineArgs": "-pluginSearchPaths $(OutDir) -language en"
+        }
+    }
+}

--- a/examples/FirstImportFormat/SampleData/SimpleTxt-Example.txt
+++ b/examples/FirstImportFormat/SampleData/SimpleTxt-Example.txt
@@ -1,0 +1,7 @@
+#Header
+Date: 2024-08-14 14:39:05
+Text: Test measurement
+
+#Characteristic,Value
+CharA, 2.4
+CharB, 1.6

--- a/examples/FirstImportFormat/SimpleTxtImportGroupFilter.cs
+++ b/examples/FirstImportFormat/SimpleTxtImportGroupFilter.cs
@@ -8,33 +8,28 @@
 
 #endregion
 
-#region usings
-
 using System.IO;
 using System.Threading.Tasks;
 using Zeiss.PiWeb.Sdk.Import.ImportFiles;
 
-#endregion
+namespace Zeiss.FirstImportFormat;
 
-namespace Zeiss.FirstImportFormat
+public class SimpleTxtImportGroupFilter : IImportGroupFilter
 {
-    public class SimpleTxtImportGroupFilter : IImportGroupFilter
+    public async ValueTask<FilterResult> FilterAsync(IImportGroup importGroup, IFilterContext context)
     {
-        public async ValueTask<FilterResult> FilterAsync(IImportGroup importGroup, IFilterContext context)
-        {
-            // Check file extension.
-            if (!importGroup.PrimaryFile.HasExtension(".txt"))
-                return FilterResult.None;
-
-            await using var stream = importGroup.PrimaryFile.GetDataStream();
-            using var reader = new StreamReader(stream);
-
-            // Check file content match with SimpleTxt format.
-            var firstLine = reader.ReadLine();
-            if (firstLine != null && firstLine.StartsWith("#Header"))
-                return FilterResult.Import;
-
+        // Check file extension.
+        if (!importGroup.PrimaryFile.HasExtension(".txt"))
             return FilterResult.None;
-        }
+
+        await using var stream = importGroup.PrimaryFile.GetDataStream();
+        using var reader = new StreamReader(stream);
+
+        // Check file content match with SimpleTxt format.
+        var firstLine = reader.ReadLine();
+        if (firstLine != null && firstLine.StartsWith("#Header"))
+            return FilterResult.Import;
+
+        return FilterResult.None;
     }
 }

--- a/examples/FirstImportFormat/SimpleTxtImportGroupFilter.cs
+++ b/examples/FirstImportFormat/SimpleTxtImportGroupFilter.cs
@@ -1,0 +1,40 @@
+﻿#region copyright
+
+/* * * * * * * * * * * * * * * * * * * * * * * * * */
+/* Carl Zeiss Industrielle Messtechnik GmbH        */
+/* Softwaresystem PiWeb                            */
+/* (c) Carl Zeiss 2024                             */
+/* * * * * * * * * * * * * * * * * * * * * * * * * */
+
+#endregion
+
+#region usings
+
+using System.IO;
+using System.Threading.Tasks;
+using Zeiss.PiWeb.Sdk.Import.ImportFiles;
+
+#endregion
+
+namespace Zeiss.FirstImportFormat
+{
+    public class SimpleTxtImportGroupFilter : IImportGroupFilter
+    {
+        public async ValueTask<FilterResult> FilterAsync(IImportGroup importGroup, IFilterContext context)
+        {
+            // Check file extension.
+            if (!importGroup.PrimaryFile.HasExtension(".txt"))
+                return FilterResult.None;
+
+            await using var stream = importGroup.PrimaryFile.GetDataStream();
+            using var reader = new StreamReader(stream);
+
+            // Check file content match with SimpleTxt format.
+            var firstLine = reader.ReadLine();
+            if (firstLine != null && firstLine.StartsWith("#Header"))
+                return FilterResult.Import;
+
+            return FilterResult.None;
+        }
+    }
+}

--- a/examples/FirstImportFormat/SimpleTxtImportParser.cs
+++ b/examples/FirstImportFormat/SimpleTxtImportParser.cs
@@ -1,0 +1,90 @@
+﻿#region copyright
+
+/* * * * * * * * * * * * * * * * * * * * * * * * * */
+/* Carl Zeiss Industrielle Messtechnik GmbH        */
+/* Softwaresystem PiWeb                            */
+/* (c) Carl Zeiss 2024                             */
+/* * * * * * * * * * * * * * * * * * * * * * * * * */
+
+#endregion
+
+#region usings
+
+using System.IO;
+using System.Threading;
+using System.Threading.Tasks;
+using Zeiss.PiWeb.Sdk.Import.ImportData;
+using Zeiss.PiWeb.Sdk.Import.ImportFiles;
+using Zeiss.PiWeb.Sdk.Import.Modules.ImportFormat;
+
+#endregion
+
+namespace Zeiss.FirstImportFormat
+{
+    public class SimpleTxtImportParser : IImportParser
+    {
+        public async Task<ImportData> ParseAsync(IImportGroup importGroup, IParseContext context,
+            CancellationToken cancellationToken = new CancellationToken())
+        {
+            // Check file extension.
+            if (!importGroup.PrimaryFile.HasExtension(".txt"))
+                throw new ImportDataException(
+                    $"Expected Simple Txt file to import, but received '{importGroup.PrimaryFile.Name}'");
+
+            await using var stream = importGroup.PrimaryFile.GetDataStream();
+            using var reader = new StreamReader(stream);
+
+            // Check file content match with SimpleTxt format.
+            var firstLine = reader.ReadLine();
+            if (firstLine == null || !firstLine.StartsWith("#Header"))
+                throw new ImportDataException("Expected Simple Txt file to start contain '#Header'");
+
+            var root = new InspectionPlanPart(importGroup.PrimaryFile.BaseName);
+            var measurement = root.AddMeasurement();
+
+            string? line;
+
+            // Parse header attributes.
+            while ((line = reader.ReadLine()) != null)
+            {
+                if( string.IsNullOrEmpty(line))
+                    continue;
+
+                if (line.StartsWith("#Characteristic"))
+                    break;
+
+                var rowItems = line.Split(": ");
+                var attribute = rowItems[0].Trim();
+                var value = rowItems[1].Trim();
+
+                switch (attribute)
+                {
+                    case "Date":
+                        measurement.SetAttribute(4,value);
+                        break;
+                    case "Text":
+                        measurement.SetAttribute(9,value);
+                        break;
+                }
+
+            }
+
+            // Parse measured value for each characteristic.
+            while ((line = reader.ReadLine()) != null)
+            {
+                if( string.IsNullOrEmpty(line))
+                    continue;
+
+                var rowItems = line.Split(',');
+                var characteristicName = rowItems[0].Trim();
+                var value = rowItems[1].Trim();
+
+                var characteristic = root.AddCharacteristic(characteristicName);
+                var measuredValue = measurement.AddMeasuredValue(characteristic);
+                measuredValue.SetAttribute(1,double.Parse(value));
+            }
+
+            return new ImportData(root);
+        }
+    }
+}

--- a/examples/FirstImportFormat/SimpleTxtImportParser.cs
+++ b/examples/FirstImportFormat/SimpleTxtImportParser.cs
@@ -8,8 +8,6 @@
 
 #endregion
 
-#region usings
-
 using System.IO;
 using System.Threading;
 using System.Threading.Tasks;
@@ -17,74 +15,71 @@ using Zeiss.PiWeb.Sdk.Import.ImportData;
 using Zeiss.PiWeb.Sdk.Import.ImportFiles;
 using Zeiss.PiWeb.Sdk.Import.Modules.ImportFormat;
 
-#endregion
+namespace Zeiss.FirstImportFormat;
 
-namespace Zeiss.FirstImportFormat
+public class SimpleTxtImportParser : IImportParser
 {
-    public class SimpleTxtImportParser : IImportParser
+    public async Task<ImportData> ParseAsync(IImportGroup importGroup, IParseContext context,
+        CancellationToken cancellationToken = new CancellationToken())
     {
-        public async Task<ImportData> ParseAsync(IImportGroup importGroup, IParseContext context,
-            CancellationToken cancellationToken = new CancellationToken())
+        // Check file extension.
+        if (!importGroup.PrimaryFile.HasExtension(".txt"))
+            throw new ImportDataException(
+                $"Expected Simple Txt file to import, but received '{importGroup.PrimaryFile.Name}'");
+
+        await using var stream = importGroup.PrimaryFile.GetDataStream();
+        using var reader = new StreamReader(stream);
+
+        // Check file content match with SimpleTxt format.
+        var firstLine = reader.ReadLine();
+        if (firstLine == null || !firstLine.StartsWith("#Header"))
+            throw new ImportDataException("Expected Simple Txt file to start contain '#Header'");
+
+        var root = new InspectionPlanPart(importGroup.PrimaryFile.BaseName);
+        var measurement = root.AddMeasurement();
+
+        string? line;
+
+        // Parse header attributes.
+        while ((line = reader.ReadLine()) != null)
         {
-            // Check file extension.
-            if (!importGroup.PrimaryFile.HasExtension(".txt"))
-                throw new ImportDataException(
-                    $"Expected Simple Txt file to import, but received '{importGroup.PrimaryFile.Name}'");
+            if (string.IsNullOrEmpty(line))
+                continue;
 
-            await using var stream = importGroup.PrimaryFile.GetDataStream();
-            using var reader = new StreamReader(stream);
+            if (line.StartsWith("#Characteristic"))
+                break;
 
-            // Check file content match with SimpleTxt format.
-            var firstLine = reader.ReadLine();
-            if (firstLine == null || !firstLine.StartsWith("#Header"))
-                throw new ImportDataException("Expected Simple Txt file to start contain '#Header'");
+            var rowItems = line.Split(": ");
+            var attribute = rowItems[0].Trim();
+            var value = rowItems[1].Trim();
 
-            var root = new InspectionPlanPart(importGroup.PrimaryFile.BaseName);
-            var measurement = root.AddMeasurement();
-
-            string? line;
-
-            // Parse header attributes.
-            while ((line = reader.ReadLine()) != null)
+            switch (attribute)
             {
-                if( string.IsNullOrEmpty(line))
-                    continue;
-
-                if (line.StartsWith("#Characteristic"))
+                case "Date":
+                    measurement.SetAttribute(4,value);
                     break;
-
-                var rowItems = line.Split(": ");
-                var attribute = rowItems[0].Trim();
-                var value = rowItems[1].Trim();
-
-                switch (attribute)
-                {
-                    case "Date":
-                        measurement.SetAttribute(4,value);
-                        break;
-                    case "Text":
-                        measurement.SetAttribute(9,value);
-                        break;
-                }
-
+                case "Text":
+                    measurement.SetAttribute(9,value);
+                    break;
             }
 
-            // Parse measured value for each characteristic.
-            while ((line = reader.ReadLine()) != null)
-            {
-                if( string.IsNullOrEmpty(line))
-                    continue;
-
-                var rowItems = line.Split(',');
-                var characteristicName = rowItems[0].Trim();
-                var value = rowItems[1].Trim();
-
-                var characteristic = root.AddCharacteristic(characteristicName);
-                var measuredValue = measurement.AddMeasuredValue(characteristic);
-                measuredValue.SetAttribute(1,double.Parse(value));
-            }
-
-            return new ImportData(root);
         }
+
+        // Parse measured value for each characteristic.
+        while ((line = reader.ReadLine()) != null)
+        {
+            if (string.IsNullOrEmpty(line))
+                continue;
+
+            var rowItems = line.Split(',');
+            var characteristicName = rowItems[0].Trim();
+            var value = rowItems[1].Trim();
+
+            var characteristic = root.AddCharacteristic(characteristicName);
+            var measuredValue = measurement.AddMeasuredValue(characteristic);
+            measuredValue.SetAttribute(1,double.Parse(value));
+        }
+
+        return new ImportData(root);
     }
 }

--- a/examples/FirstImportFormat/manifest.json
+++ b/examples/FirstImportFormat/manifest.json
@@ -1,0 +1,14 @@
+{
+  "id": "SimpleTxtFormat",
+  "version": "1.0.0",
+  "title": "SimpleTxt Format",
+  "description": "The SimpleTxt Format is a simple format for the demonstration of import format plug-ins.",
+  "author": "Zeiss",
+  "provides": {
+    "type": "ImportFormat",
+    "displayName": "SimpleTxt",
+    "fileExtensions": [
+      ".txt"
+    ]
+  }
+}

--- a/examples/PiWebImportSdkExamples.sln
+++ b/examples/PiWebImportSdkExamples.sln
@@ -14,6 +14,8 @@ Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "Projektmappenelemente", "Pr
 		.editorconfig = .editorconfig
 	EndProjectSection
 EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "FirstImportFormat", "FirstImportFormat\FirstImportFormat.csproj", "{21224634-FEEC-48B7-9B9E-355CC20B1B85}"
+EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
 		Debug|Any CPU = Debug|Any CPU
@@ -32,6 +34,10 @@ Global
 		{F24BEAEE-81F7-4A28-922E-4D10E3EE1CAA}.Debug|Any CPU.Build.0 = Debug|Any CPU
 		{F24BEAEE-81F7-4A28-922E-4D10E3EE1CAA}.Release|Any CPU.ActiveCfg = Release|Any CPU
 		{F24BEAEE-81F7-4A28-922E-4D10E3EE1CAA}.Release|Any CPU.Build.0 = Release|Any CPU
+		{21224634-FEEC-48B7-9B9E-355CC20B1B85}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{21224634-FEEC-48B7-9B9E-355CC20B1B85}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{21224634-FEEC-48B7-9B9E-355CC20B1B85}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{21224634-FEEC-48B7-9B9E-355CC20B1B85}.Release|Any CPU.Build.0 = Release|Any CPU
 	EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE

--- a/examples/PiWebImportSdkExamples.sln
+++ b/examples/PiWebImportSdkExamples.sln
@@ -16,6 +16,8 @@ Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "Projektmappenelemente", "Pr
 EndProject
 Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "FirstImportFormat", "FirstImportFormat\FirstImportFormat.csproj", "{21224634-FEEC-48B7-9B9E-355CC20B1B85}"
 EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "SecondImportFormat", "SecondImportFormat\SecondImportFormat.csproj", "{F0778736-BF6A-4D56-B8F2-0BAB9A24B668}"
+EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
 		Debug|Any CPU = Debug|Any CPU
@@ -38,6 +40,10 @@ Global
 		{21224634-FEEC-48B7-9B9E-355CC20B1B85}.Debug|Any CPU.Build.0 = Debug|Any CPU
 		{21224634-FEEC-48B7-9B9E-355CC20B1B85}.Release|Any CPU.ActiveCfg = Release|Any CPU
 		{21224634-FEEC-48B7-9B9E-355CC20B1B85}.Release|Any CPU.Build.0 = Release|Any CPU
+		{F0778736-BF6A-4D56-B8F2-0BAB9A24B668}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{F0778736-BF6A-4D56-B8F2-0BAB9A24B668}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{F0778736-BF6A-4D56-B8F2-0BAB9A24B668}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{F0778736-BF6A-4D56-B8F2-0BAB9A24B668}.Release|Any CPU.Build.0 = Release|Any CPU
 	EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE

--- a/examples/SecondImportAutomation/Properties/launchSettings.json
+++ b/examples/SecondImportAutomation/Properties/launchSettings.json
@@ -2,8 +2,9 @@
     "profiles": {
         "AutoImporter": {
             "commandName": "Executable",
-            "executablePath": "C:\\Program Files\\Zeiss\\PiWeb\\AutoImporter.exe",
-            "commandLineArgs": "-pluginSearchPaths $(MSBuildThisFileDirectory)\\bin\\Debug -language en"
+            "workingDirectory": "$(ProjectDir)",
+            "executablePath": "%ProgramFiles%\\Zeiss\\PiWeb\\AutoImporter.exe",
+            "commandLineArgs": "-pluginSearchPaths $(OutDir)"
         }
     }
 }

--- a/examples/SecondImportAutomation/SecondImportAutomation.csproj
+++ b/examples/SecondImportAutomation/SecondImportAutomation.csproj
@@ -1,23 +1,23 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
-    <PropertyGroup>
-        <TargetFramework>net8.0</TargetFramework>
-        <Nullable>enable</Nullable>
-        <AssemblyName>Zeiss.SecondImportAutomation</AssemblyName>
-        <RootNamespace>Zeiss.SecondImportAutomation</RootNamespace>
-    </PropertyGroup>
+  <PropertyGroup>
+    <TargetFramework>net8.0</TargetFramework>
+    <Nullable>enable</Nullable>
+    <EnableDynamicLoading>true</EnableDynamicLoading>
+    <GeneratePluginPackageOnBuild>true</GeneratePluginPackageOnBuild>
+    <AssemblyName>Zeiss.SecondImportAutomation</AssemblyName>
+    <RootNamespace>Zeiss.SecondImportAutomation</RootNamespace>
+    <Authors>Carl Zeiss IMT GmbH</Authors>
+    <Company>Carl Zeiss IMT GmbH</Company>
+  </PropertyGroup>
 
-    <ItemGroup>
-        <None Update="manifest.json" CopyToOutputDirectory="PreserveNewest" />
-    </ItemGroup>
+  <ItemGroup>
+    <PackageReference Include="Zeiss.PiWeb.Sdk.Import" Version="1.0.0" Private="false" ExcludeAssets="runtime"/>
+    <PackageReference Include="Zeiss.PiWeb.Api.Rest" Version="9.0.0" />
+  </ItemGroup>
 
-    <ItemGroup>
-        <PackageReference Include="Zeiss.PiWeb.Sdk.Import" Version="1.0.0-beta0058-97">
-            <Private>false</Private>
-            <ExcludeAssets>runtime</ExcludeAssets>
-        </PackageReference>
-
-        <PackageReference Include="Zeiss.PiWeb.Api.Rest" Version="8.4.0-beta0004-137" />
-    </ItemGroup>
+  <ItemGroup>
+    <None Update="manifest.json" CopyToOutputDirectory="PreserveNewest"/>
+  </ItemGroup>
 
 </Project>

--- a/examples/SecondImportFormat/ImportFormat.cs
+++ b/examples/SecondImportFormat/ImportFormat.cs
@@ -8,12 +8,8 @@
 
 #endregion
 
-#region usings
-
 using Zeiss.PiWeb.Sdk.Import.ImportFiles;
 using Zeiss.PiWeb.Sdk.Import.Modules.ImportFormat;
-
-#endregion
 
 namespace Zeiss.SecondImportFormat;
 

--- a/examples/SecondImportFormat/ImportFormat.cs
+++ b/examples/SecondImportFormat/ImportFormat.cs
@@ -1,0 +1,65 @@
+﻿#region copyright
+
+/* * * * * * * * * * * * * * * * * * * * * * * * * */
+/* Carl Zeiss Industrielle Messtechnik GmbH        */
+/* Softwaresystem PiWeb                            */
+/* (c) Carl Zeiss 2024                             */
+/* * * * * * * * * * * * * * * * * * * * * * * * * */
+
+#endregion
+
+#region usings
+
+using Zeiss.PiWeb.Sdk.Import.ImportFiles;
+using Zeiss.PiWeb.Sdk.Import.Modules.ImportFormat;
+
+#endregion
+
+namespace Zeiss.SecondImportFormat;
+
+public sealed class ImportFormat : IImportFormat
+{
+    public IImportGroupFilter CreateImportGroupFilter(ICreateImportGroupFilterContext context)
+    {
+        return new ImportGroupFilter();
+    }
+
+    public IImportParser CreateImportParser(ICreateImportParserContext context)
+    {
+        return new ImportParser();
+    }
+
+    public IImportFormatConfiguration CreateConfiguration(ICreateImportFormatConfigurationContext context)
+    {
+        return new ImportFormatConfiguration
+        {
+            SupportsPathRules = true,
+            SupportsAttributeMapping = true,
+            DefaultAttributeMappingConfiguration = new AttributeMappingConfiguration
+            {
+                MappingRules =
+                [
+                    new MappingRule
+                    {
+                        MappingTarget = MappingTarget.MeasuredValue,
+                        AttributeKey = 1, // Measured Value
+                        ValueExpression = "$Value"
+                    },
+                    new MappingRule
+                    {
+                        MappingTarget = MappingTarget.Measurement,
+                        AttributeKey = 4, // Time
+                        ValueExpression = "$Date",
+                        MappingCultureName = "de-DE"
+                    },
+                    new MappingRule
+                    {
+                        MappingTarget = MappingTarget.Measurement,
+                        AttributeKey = 9, // Text
+                        ValueExpression = "$Text"
+                    }
+                ]
+            }
+        };
+    }
+}

--- a/examples/SecondImportFormat/ImportGroupFilter.cs
+++ b/examples/SecondImportFormat/ImportGroupFilter.cs
@@ -8,31 +8,25 @@
 
 #endregion
 
-#region usings
-
-using System.IO;
 using System.Threading.Tasks;
 using Zeiss.PiWeb.Sdk.Import.ImportFiles;
 
-#endregion
+namespace Zeiss.SecondImportFormat;
 
-namespace Zeiss.SecondImportFormat
+public class ImportGroupFilter : IImportGroupFilter
 {
-    public class ImportGroupFilter : IImportGroupFilter
+    public async ValueTask<FilterResult> FilterAsync(IImportGroup importGroup, IFilterContext context)
     {
-        public async ValueTask<FilterResult> FilterAsync(IImportGroup importGroup, IFilterContext context)
-        {
-            // Check file extension.
-            if (!importGroup.PrimaryFile.HasExtension(".txt"))
-                return FilterResult.None;
+        // Check file extension.
+        if (!importGroup.PrimaryFile.HasExtension(".txt"))
+            return FilterResult.None;
 
-            // Add additional data to import group.
-            var additionalData = context.CurrentImportFolder.FindFile(importGroup.PrimaryFile.BaseName + ".png");
-            if (additionalData == null)
-                return FilterResult.RetryOrImport;
-            importGroup.AddFile(additionalData);
+        // Add additional data to import group.
+        var additionalData = context.CurrentImportFolder.FindFile(importGroup.PrimaryFile.BaseName + ".png");
+        if (additionalData == null)
+            return FilterResult.RetryOrImport;
+        importGroup.AddFile(additionalData);
 
-            return FilterResult.Import;
-        }
+        return FilterResult.Import;
     }
 }

--- a/examples/SecondImportFormat/ImportGroupFilter.cs
+++ b/examples/SecondImportFormat/ImportGroupFilter.cs
@@ -1,0 +1,38 @@
+﻿#region copyright
+
+/* * * * * * * * * * * * * * * * * * * * * * * * * */
+/* Carl Zeiss Industrielle Messtechnik GmbH        */
+/* Softwaresystem PiWeb                            */
+/* (c) Carl Zeiss 2024                             */
+/* * * * * * * * * * * * * * * * * * * * * * * * * */
+
+#endregion
+
+#region usings
+
+using System.IO;
+using System.Threading.Tasks;
+using Zeiss.PiWeb.Sdk.Import.ImportFiles;
+
+#endregion
+
+namespace Zeiss.SecondImportFormat
+{
+    public class ImportGroupFilter : IImportGroupFilter
+    {
+        public async ValueTask<FilterResult> FilterAsync(IImportGroup importGroup, IFilterContext context)
+        {
+            // Check file extension.
+            if (!importGroup.PrimaryFile.HasExtension(".txt"))
+                return FilterResult.None;
+
+            // Add additional data to import group.
+            var additionalData = context.CurrentImportFolder.FindFile(importGroup.PrimaryFile.BaseName + ".png");
+            if (additionalData == null)
+                return FilterResult.RetryOrImport;
+            importGroup.AddFile(additionalData);
+
+            return FilterResult.Import;
+        }
+    }
+}

--- a/examples/SecondImportFormat/ImportParser.cs
+++ b/examples/SecondImportFormat/ImportParser.cs
@@ -1,0 +1,85 @@
+﻿#region copyright
+
+/* * * * * * * * * * * * * * * * * * * * * * * * * */
+/* Carl Zeiss Industrielle Messtechnik GmbH        */
+/* Softwaresystem PiWeb                            */
+/* (c) Carl Zeiss 2024                             */
+/* * * * * * * * * * * * * * * * * * * * * * * * * */
+
+#endregion
+
+#region usings
+
+using System.IO;
+using System.Threading;
+using System.Threading.Tasks;
+using Zeiss.PiWeb.Sdk.Import.ImportData;
+using Zeiss.PiWeb.Sdk.Import.ImportFiles;
+using Zeiss.PiWeb.Sdk.Import.Modules.ImportFormat;
+
+#endregion
+
+namespace Zeiss.SecondImportFormat
+{
+    public class ImportParser : IImportParser
+    {
+        public async Task<ImportData> ParseAsync(IImportGroup importGroup, IParseContext context,
+            CancellationToken cancellationToken = new CancellationToken())
+        {
+            // Create root part and measurement.
+            var root = new InspectionPlanPart(importGroup.PrimaryFile.BaseName);
+            var measurement = root.AddMeasurement();
+
+            // Create reader for import file.
+            await using var stream = importGroup.PrimaryFile.GetDataStream();
+            using var reader = new StreamReader(stream);
+
+            string? line;
+
+            // Parse header attributes.
+            while ((line = reader.ReadLine()) != null)
+            {
+                if( string.IsNullOrEmpty(line))
+                    continue;
+
+                if (line.StartsWith("#Characteristic"))
+                    break;
+
+                var rowItems = line.Split(": ");
+                var attribute = rowItems[0].Trim();
+                var value = rowItems[1].Trim();
+
+                switch (attribute)
+                {
+                    case "Date":
+                        measurement.SetVariable("Date",value);
+                        break;
+                    case "Text":
+                        measurement.SetVariable("Text",value);
+                        break;
+                }
+            }
+
+            // Parse measured value for each characteristic.
+            while ((line = reader.ReadLine()) != null)
+            {
+                if( string.IsNullOrEmpty(line))
+                    continue;
+
+                var rowItems = line.Split(',');
+                var characteristicName = rowItems[0].Trim();
+                var value = rowItems[1].Trim();
+
+                var characteristic = root.AddCharacteristic(characteristicName);
+                var measuredValue = measurement.AddMeasuredValue(characteristic);
+                measuredValue.SetVariable("Value",double.Parse(value));
+            }
+
+            // Add additional data.
+            foreach (var rawData in importGroup.AdditionalFiles)
+                measurement.AddAdditionalData(rawData.Name, rawData.GetDataStream());
+
+            return new ImportData(root);
+        }
+    }
+}

--- a/examples/SecondImportFormat/ImportParser.cs
+++ b/examples/SecondImportFormat/ImportParser.cs
@@ -8,8 +8,6 @@
 
 #endregion
 
-#region usings
-
 using System.IO;
 using System.Threading;
 using System.Threading.Tasks;
@@ -17,69 +15,58 @@ using Zeiss.PiWeb.Sdk.Import.ImportData;
 using Zeiss.PiWeb.Sdk.Import.ImportFiles;
 using Zeiss.PiWeb.Sdk.Import.Modules.ImportFormat;
 
-#endregion
+namespace Zeiss.SecondImportFormat;
 
-namespace Zeiss.SecondImportFormat
+public class ImportParser : IImportParser
 {
-    public class ImportParser : IImportParser
+    public async Task<ImportData> ParseAsync(IImportGroup importGroup, IParseContext context,
+        CancellationToken cancellationToken = new CancellationToken())
     {
-        public async Task<ImportData> ParseAsync(IImportGroup importGroup, IParseContext context,
-            CancellationToken cancellationToken = new CancellationToken())
+        // Create root part and measurement.
+        var root = new InspectionPlanPart(importGroup.PrimaryFile.BaseName);
+        var measurement = root.AddMeasurement();
+
+        // Create reader for import file.
+        await using var stream = importGroup.PrimaryFile.GetDataStream();
+        using var reader = new StreamReader(stream);
+
+        string? line;
+
+        // Parse header attributes.
+        while ((line = reader.ReadLine()) != null)
         {
-            // Create root part and measurement.
-            var root = new InspectionPlanPart(importGroup.PrimaryFile.BaseName);
-            var measurement = root.AddMeasurement();
+            if (string.IsNullOrEmpty(line))
+                continue;
 
-            // Create reader for import file.
-            await using var stream = importGroup.PrimaryFile.GetDataStream();
-            using var reader = new StreamReader(stream);
+            if (line.StartsWith("#Characteristic"))
+                break;
 
-            string? line;
+            var rowItems = line.Split(": ");
+            var attribute = rowItems[0].Trim();
+            var value = rowItems[1].Trim();
 
-            // Parse header attributes.
-            while ((line = reader.ReadLine()) != null)
-            {
-                if( string.IsNullOrEmpty(line))
-                    continue;
-
-                if (line.StartsWith("#Characteristic"))
-                    break;
-
-                var rowItems = line.Split(": ");
-                var attribute = rowItems[0].Trim();
-                var value = rowItems[1].Trim();
-
-                switch (attribute)
-                {
-                    case "Date":
-                        measurement.SetVariable("Date",value);
-                        break;
-                    case "Text":
-                        measurement.SetVariable("Text",value);
-                        break;
-                }
-            }
-
-            // Parse measured value for each characteristic.
-            while ((line = reader.ReadLine()) != null)
-            {
-                if( string.IsNullOrEmpty(line))
-                    continue;
-
-                var rowItems = line.Split(',');
-                var characteristicName = rowItems[0].Trim();
-                var value = rowItems[1].Trim();
-
-                var characteristic = root.AddCharacteristic(characteristicName);
-                var measuredValue = measurement.AddMeasuredValue(characteristic);
-                measuredValue.SetVariable("Value",double.Parse(value));
-            }
-
-            // Add additional data.
-            foreach (var rawData in importGroup.AdditionalFiles)
-                measurement.AddAdditionalData(rawData.Name, rawData.GetDataStream());
-
-            return new ImportData(root);
+            measurement.SetVariable(attribute,value);
         }
+
+        // Parse measured value for each characteristic.
+        while ((line = reader.ReadLine()) != null)
+        {
+            if (string.IsNullOrEmpty(line))
+                continue;
+
+            var rowItems = line.Split(',');
+            var characteristicName = rowItems[0].Trim();
+            var value = rowItems[1].Trim();
+
+            var characteristic = root.AddCharacteristic(characteristicName);
+            var measuredValue = measurement.AddMeasuredValue(characteristic);
+            measuredValue.SetVariable("Value",double.Parse(value));
+        }
+
+        // Add additional data.
+        foreach (var rawData in importGroup.AdditionalFiles)
+            measurement.AddAdditionalData(rawData.Name, rawData.GetDataStream());
+
+        return new ImportData(root);
     }
 }

--- a/examples/SecondImportFormat/Plugin.cs
+++ b/examples/SecondImportFormat/Plugin.cs
@@ -8,12 +8,8 @@
 
 #endregion
 
-#region usings
-
 using Zeiss.PiWeb.Sdk.Import;
 using Zeiss.PiWeb.Sdk.Import.Modules.ImportFormat;
-
-#endregion
 
 namespace Zeiss.SecondImportFormat;
 

--- a/examples/SecondImportFormat/Plugin.cs
+++ b/examples/SecondImportFormat/Plugin.cs
@@ -1,0 +1,27 @@
+﻿#region copyright
+
+/* * * * * * * * * * * * * * * * * * * * * * * * * */
+/* Carl Zeiss Industrielle Messtechnik GmbH        */
+/* Softwaresystem PiWeb                            */
+/* (c) Carl Zeiss 2024                             */
+/* * * * * * * * * * * * * * * * * * * * * * * * * */
+
+#endregion
+
+#region usings
+
+using Zeiss.PiWeb.Sdk.Import;
+using Zeiss.PiWeb.Sdk.Import.Modules.ImportFormat;
+
+#endregion
+
+namespace Zeiss.SecondImportFormat;
+
+public class Plugin : IPlugin
+{
+    /// <inheritdoc />
+    public IImportFormat CreateImportFormat(ICreateImportFormatContext context)
+    {
+        return new ImportFormat();
+    }
+}

--- a/examples/SecondImportFormat/Properties/launchSettings.json
+++ b/examples/SecondImportFormat/Properties/launchSettings.json
@@ -1,0 +1,10 @@
+{
+    "profiles": {
+        "AutoImporter": {
+            "commandName": "Executable",
+            "workingDirectory": "$(ProjectDir)",
+            "executablePath": "%ProgramFiles%\\Zeiss\\PiWeb\\AutoImporter.exe",
+            "commandLineArgs": "-pluginSearchPaths $(OutDir)"
+        }
+    }
+}

--- a/examples/SecondImportFormat/SampleData/SimpleTxt-Example.txt
+++ b/examples/SecondImportFormat/SampleData/SimpleTxt-Example.txt
@@ -1,0 +1,7 @@
+#Header
+Date: 2024-08-14 14:39:05
+Text: Test measurement
+
+#Characteristic,Value
+CharA, 2.4
+CharB, 1.6

--- a/examples/SecondImportFormat/SecondImportFormat.csproj
+++ b/examples/SecondImportFormat/SecondImportFormat.csproj
@@ -1,0 +1,24 @@
+﻿<Project Sdk="Microsoft.NET.Sdk">
+
+  <PropertyGroup>
+    <TargetFramework>net8.0</TargetFramework>
+    <Nullable>enable</Nullable>
+    <EnableDynamicLoading>true</EnableDynamicLoading>
+    <GeneratePluginPackageOnBuild>true</GeneratePluginPackageOnBuild>
+    <RootNamespace>Zeiss.SecondImportFormat</RootNamespace>
+    <PackageId>Zeiss.SecondImportFormat</PackageId>
+    <Authors>Carl Zeiss IMT GmbH</Authors>
+    <Company>Carl Zeiss IMT GmbH</Company>
+    <Product>Zeiss.SecondImportFormat</Product>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <PackageReference Include="Zeiss.PiWeb.Sdk.Import" Version="1.0.0" Private="false" ExcludeAssets="runtime"/>
+  </ItemGroup>
+
+  <ItemGroup>
+    <None Update="manifest.json" CopyToOutputDirectory="PreserveNewest"/>
+    <None Update="SampleData/**" CopyToOutputDirectory="PreserveNewest"/>
+  </ItemGroup>
+  
+</Project>

--- a/examples/SecondImportFormat/manifest.json
+++ b/examples/SecondImportFormat/manifest.json
@@ -1,0 +1,14 @@
+{
+  "id": "SimpleTxtFormatExtended",
+  "version": "1.0.0",
+  "title": "SimpleTxt Format Extended",
+  "description": "The SimpleTxt Format is a simple format for the demonstration of import format plug-ins. This is the extended version of the plug-in.",
+  "author": "Zeiss",
+  "provides": {
+    "type": "ImportFormat",
+    "displayName": "SimpleTxt",
+    "fileExtensions": [
+      ".txt"
+    ]
+  }
+}

--- a/examples/StartingAPlugin/Properties/launchSettings.json
+++ b/examples/StartingAPlugin/Properties/launchSettings.json
@@ -2,8 +2,9 @@
     "profiles": {
         "AutoImporter": {
             "commandName": "Executable",
-            "executablePath": "C:\\Program Files\\Zeiss\\PiWeb\\AutoImporter.exe",
-            "commandLineArgs": "-pluginSearchPaths $(MSBuildThisFileDirectory)\\bin\\Debug -language en"
+            "workingDirectory": "$(ProjectDir)",
+            "executablePath": "%ProgramFiles%\\Zeiss\\PiWeb\\AutoImporter.exe",
+            "commandLineArgs": "-pluginSearchPaths $(OutDir)"
         }
     }
 }

--- a/examples/StartingAPlugin/StartingAPlugin.csproj
+++ b/examples/StartingAPlugin/StartingAPlugin.csproj
@@ -1,23 +1,23 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
-    <PropertyGroup>
-        <TargetFramework>net8.0</TargetFramework>
-        <Nullable>enable</Nullable>
-        <AssemblyName>Zeiss.StartingAPlugin</AssemblyName>
-        <RootNamespace>Zeiss.StartingAPlugin</RootNamespace>
-    </PropertyGroup>
+  <PropertyGroup>
+    <TargetFramework>net8.0</TargetFramework>
+    <Nullable>enable</Nullable>
+    <EnableDynamicLoading>true</EnableDynamicLoading>
+    <GeneratePluginPackageOnBuild>true</GeneratePluginPackageOnBuild>
+    <AssemblyName>Zeiss.StartingAPlugin</AssemblyName>
+    <RootNamespace>Zeiss.StartingAPlugin</RootNamespace>
+    <Authors>Carl Zeiss IMT GmbH</Authors>
+    <Company>Carl Zeiss IMT GmbH</Company>
+  </PropertyGroup>
 
-    <ItemGroup>
-        <None Update="manifest.json" CopyToOutputDirectory="PreserveNewest"/>
-    </ItemGroup>
+  <ItemGroup>
+    <PackageReference Include="Zeiss.PiWeb.Sdk.Import" Version="1.0.0" Private="false" ExcludeAssets="runtime"/>
+    <PackageReference Include="Zeiss.PiWeb.Api.Rest" Version="9.0.0" />
+  </ItemGroup>
 
-    <ItemGroup>
-        <PackageReference Include="Zeiss.PiWeb.Sdk.Import" Version="1.0.0-beta0058-97">
-            <Private>false</Private>
-            <ExcludeAssets>runtime</ExcludeAssets>
-        </PackageReference>
-
-        <PackageReference Include="Zeiss.PiWeb.Api.Rest" Version="8.4.0-beta0004-137" />
-    </ItemGroup>
+  <ItemGroup>
+    <None Update="manifest.json" CopyToOutputDirectory="PreserveNewest"/>
+  </ItemGroup>
 
 </Project>


### PR DESCRIPTION
This PR adds two projects for example plug-ins for import format plug-ins. The example plug-ins are used for the documentation of the PiWeb Import SDK. 

In addition the launch settings and project files for all example plug-ins are aligned with settings in the project template. 