### PR TITLE
Fix mismatch of plug-in id and assembly name in examples

### DIFF
--- a/examples/FirstImportAutomation/FirstImportAutomation.csproj
+++ b/examples/FirstImportAutomation/FirstImportAutomation.csproj
@@ -8,6 +8,7 @@
     <RootNamespace>Zeiss.FirstImportAutomation</RootNamespace>
     <Authors>Carl Zeiss IMT GmbH</Authors>
     <Company>Carl Zeiss IMT GmbH</Company>
+    <AssemblyName>Zeiss.FirstImportAutomation</AssemblyName>
   </PropertyGroup>
 
   <ItemGroup>

--- a/examples/FirstImportAutomation/manifest.json
+++ b/examples/FirstImportAutomation/manifest.json
@@ -1,11 +1,11 @@
 {
     "id": "Zeiss.FirstImportAutomation",
-    "title": "FirstImportAutomation",
+    "title": "First Import Automation",
     "description": "This plug-in is used in the Import SDK documentation to create an initial import automation.",
 
     "provides": {
         "type": "ImportAutomation",
-        "displayName": "FirstImportAutomation",
+        "displayName": "First Import Automation",
         "summary": "This automation checks a given PiWeb server for the existence of the 'FirstImportAutomationPart' part below the root node."
     }
 }

--- a/examples/FirstImportFormat/FirstImportFormat.csproj
+++ b/examples/FirstImportFormat/FirstImportFormat.csproj
@@ -10,6 +10,7 @@
     <Company>Carl Zeiss IMT GmbH</Company>
     <Product>Zeiss.FirstImportFormat</Product>
     <PackageId>Zeiss.FirstImportFormat</PackageId>
+    <AssemblyName>Zeiss.FirstImportFormat</AssemblyName>
   </PropertyGroup>
 
   <ItemGroup>

--- a/examples/FirstImportFormat/manifest.json
+++ b/examples/FirstImportFormat/manifest.json
@@ -1,14 +1,11 @@
 {
-  "id": "SimpleTxtFormat",
-  "version": "1.0.0",
-  "title": "SimpleTxt Format",
-  "description": "The SimpleTxt Format is a simple format for the demonstration of import format plug-ins.",
-  "author": "Zeiss",
-  "provides": {
-    "type": "ImportFormat",
-    "displayName": "SimpleTxt",
-    "fileExtensions": [
-      ".txt"
-    ]
-  }
+    "id": "Zeiss.FirstImportFormat",
+    "version": "1.0.0",
+    "title": "First Import Format",
+    "description": "This plug-in is used in the Import SDK documentation to create an initial import format plug-in. With this plug-in files of the SimpleTxt format can be imported.",
+    "provides": {
+        "type": "ImportFormat",
+        "displayName": "SimpleTxt",
+        "fileExtensions": [".txt"]
+    }
 }

--- a/examples/SecondImportAutomation/manifest.json
+++ b/examples/SecondImportAutomation/manifest.json
@@ -1,12 +1,11 @@
 {
     "id": "Zeiss.SecondImportAutomation",
     "version": "1.0.0",
-    "title": "SecondImportAutomation",
-    "description": "This plug-in is used in the Import SDK documentation to create an import automation.",
-
+    "title": "Second Import Automation",
+    "description": "This plug-in is used in the Import SDK documentation to create an import automation plug-in.",
     "provides": {
         "type": "ImportAutomation",
-        "displayName": "SecondImportAutomation",
+        "displayName": "Second Import Automation",
         "summary": "This automation reads and writes parts and measurements to a given PiWeb Server."
     }
 }

--- a/examples/SecondImportFormat/SecondImportFormat.csproj
+++ b/examples/SecondImportFormat/SecondImportFormat.csproj
@@ -10,6 +10,7 @@
     <Authors>Carl Zeiss IMT GmbH</Authors>
     <Company>Carl Zeiss IMT GmbH</Company>
     <Product>Zeiss.SecondImportFormat</Product>
+    <AssemblyName>Zeiss.SecondImportFormat</AssemblyName>
   </PropertyGroup>
 
   <ItemGroup>

--- a/examples/SecondImportFormat/manifest.json
+++ b/examples/SecondImportFormat/manifest.json
@@ -1,14 +1,12 @@
 {
-  "id": "SimpleTxtFormatExtended",
-  "version": "1.0.0",
-  "title": "SimpleTxt Format Extended",
-  "description": "The SimpleTxt Format is a simple format for the demonstration of import format plug-ins. This is the extended version of the plug-in.",
-  "author": "Zeiss",
-  "provides": {
-    "type": "ImportFormat",
-    "displayName": "SimpleTxt",
-    "fileExtensions": [
-      ".txt"
-    ]
-  }
+    "id": "Zeiss.SecondImportFormat",
+    "version": "1.0.0",
+    "title": "Second Import Format",
+    "description": "This plug-in is used in the Import SDK documentation to create an import format plug-in. With this plug-in files of the SimpleTxt format can be imported.",
+    "provides": {
+        "type": "ImportFormat",
+        "displayName": "SimpleTxt",
+        "defaultPriority":  10,
+        "fileExtensions": [".txt"]
+    }
 }

--- a/examples/StartingAPlugin/manifest.json
+++ b/examples/StartingAPlugin/manifest.json
@@ -3,7 +3,6 @@
     "version": "1.0.0",
     "title": "Starting a plug-in",
     "description": "This is a documentation plug-in to demonstrate how to start a first plug-in.",
-
     "contact": "info.metrology.de@zeiss.com",
     "documentation": "https://zeiss-piweb.github.io/PiWeb-Import-Sdk/",
     "homepage": "https://www.zeiss.de/messtechnik/produkte/software/piweb.html",
@@ -11,7 +10,6 @@
     "licenseName": "BSD-3-Clause",
     "licenseUrl": "https://github.com/ZEISS-PiWeb/PiWeb-Import-Sdk/blob/develop/LICENSE.txt",
     "sourceCode": "https://github.com/ZEISS-PiWeb/PiWeb-Import-Sdk",
-
     "provides": {
         "type": "ImportAutomation",
         "displayName": "Our custom import source",


### PR DESCRIPTION
This PR fixes a mismatch of the plug-in id and the assembly name in the example plug-in projects. 
In addition, the titles and descriptions of the plug-ins have also been unified.