### PR TITLE
Provide full import path information

### DIFF
--- a/src/PiWeb.Sdk.Import/Import/ImportData/ImportData.cs
+++ b/src/PiWeb.Sdk.Import/Import/ImportData/ImportData.cs
@@ -30,4 +30,9 @@ public class ImportData
     /// and optionally the path rule configuration.
     /// </summary>
     public InspectionPlanPart RootPart { get; set; }
+    
+    /// <summary>
+    /// The names of the parts in the import path (after applying the path rules if there are any).
+    /// </summary>
+    public string[] ImportPartPath { get; set; } = [];
 }


### PR DESCRIPTION
`ImportData `now also provides the part names of the import path. The import part is the import root part and the parts that were created using path rules.