### PR TITLE
Requeue import files

### DIFF
--- a/.github/workflows/create-release.yml
+++ b/.github/workflows/create-release.yml
@@ -20,5 +20,5 @@ jobs:
     uses: ZEISS-PiWeb/github-actions/.github/workflows/create-release.yml@main
     with:
       generate_release_notes: true
-      dotnet_version: '8.0.x'
+      dotnet_version: '10.0.x'
     secrets: inherit

--- a/.github/workflows/create-support-release.yml
+++ b/.github/workflows/create-support-release.yml
@@ -18,5 +18,5 @@ jobs:
     uses: ZEISS-PiWeb/github-actions/.github/workflows/create-support-release.yml@main
     with:
       generate_release_notes: true
-      dotnet_version: '8.0.x'
+      dotnet_version: '10.0.x'
     secrets: inherit

--- a/.github/workflows/develop.yml
+++ b/.github/workflows/develop.yml
@@ -18,5 +18,5 @@ jobs:
     uses: ZEISS-PiWeb/github-actions/.github/workflows/develop.yml@main
     with:
       do_pack: true  
-      dotnet_version: '8.0.x'
+      dotnet_version: '10.0.x'
     secrets: inherit

--- a/.github/workflows/feature-branch.yml
+++ b/.github/workflows/feature-branch.yml
@@ -16,5 +16,5 @@ jobs:
     uses: ZEISS-PiWeb/github-actions/.github/workflows/feature-branch.yml@main
     with:
       do_pack: true  
-      dotnet_version: '8.0.x'
+      dotnet_version: '10.0.x'
     secrets: inherit

--- a/global.json
+++ b/global.json
@@ -1,6 +1,6 @@
 {
   "sdk": {
-    "version": "8.0.100",
+    "version": "10.0.100",
     "allowPrerelease": false,
     "rollForward": "latestFeature"
   }

--- a/src/PiWeb.Sdk.Import.Tests/PiWeb.Sdk.Import.Tests.csproj
+++ b/src/PiWeb.Sdk.Import.Tests/PiWeb.Sdk.Import.Tests.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>net8.0</TargetFramework>
+    <TargetFramework>net10.0</TargetFramework>
     <Nullable>enable</Nullable>
     <AssemblyName>Zeiss.PiWeb.Sdk.Import.Tests</AssemblyName>
     <RootNamespace>Zeiss.PiWeb.Sdk.Import.Tests</RootNamespace>

--- a/src/PiWeb.Sdk.Import/Import/ImportController/Exceptions/ImportControllerException.cs
+++ b/src/PiWeb.Sdk.Import/Import/ImportController/Exceptions/ImportControllerException.cs
@@ -1,0 +1,42 @@
+﻿#region copyright
+
+/* * * * * * * * * * * * * * * * * * * * * * * * * */
+/* Carl Zeiss Industrielle Messtechnik GmbH        */
+/* Softwaresystem PiWeb                            */
+/* (c) Carl Zeiss 2023                             */
+/* * * * * * * * * * * * * * * * * * * * * * * * * */
+
+#endregion
+
+using System;
+using Zeiss.PiWeb.Sdk.Common.Exceptions;
+
+namespace Zeiss.PiWeb.Sdk.Import.ImportController.Exceptions;
+
+/// <summary>
+/// Represents an error when using an import controller.
+/// </summary>
+public class ImportControllerException : PluginException
+{
+	#region constructors
+
+	/// <summary>
+	/// Initializes a new instance of the <see cref="ImportControllerException"/> class.
+	/// </summary>
+	/// <param name="message">The message that describes the error.</param>
+	public ImportControllerException( string message ) : base( message )
+	{ }
+
+	/// <summary>
+	/// Initializes a new instance of the <see cref="ImportControllerException"/> class.
+	/// </summary>
+	/// <param name="message">The message that describes the error.</param>
+	/// <param name="innerException">
+	/// The exception that is the cause of the current exception, or a null reference if no inner exception is specified.
+	/// </param>
+	public ImportControllerException( string message, Exception? innerException ) : base( message, innerException )
+	{
+	}
+
+	#endregion
+}

--- a/src/PiWeb.Sdk.Import/Import/ImportController/Exceptions/SchedulingException.cs
+++ b/src/PiWeb.Sdk.Import/Import/ImportController/Exceptions/SchedulingException.cs
@@ -1,0 +1,41 @@
+﻿#region copyright
+
+/* * * * * * * * * * * * * * * * * * * * * * * * * */
+/* Carl Zeiss Industrielle Messtechnik GmbH        */
+/* Softwaresystem PiWeb                            */
+/* (c) Carl Zeiss 2023                             */
+/* * * * * * * * * * * * * * * * * * * * * * * * * */
+
+#endregion
+
+using System;
+
+namespace Zeiss.PiWeb.Sdk.Import.ImportController.Exceptions;
+
+/// <summary>
+/// Represents an error when an import file is rescheduled.
+/// </summary>
+public class SchedulingException : ImportControllerException
+{
+	#region constructors
+
+	/// <summary>
+	/// Initializes a new instance of the <see cref="SchedulingException"/> class.
+	/// </summary>
+	/// <param name="message">The message that describes the error.</param>
+	public SchedulingException( string message ) : base( message )
+	{ }
+
+	/// <summary>
+	/// Initializes a new instance of the <see cref="SchedulingException"/> class.
+	/// </summary>
+	/// <param name="message">The message that describes the error.</param>
+	/// <param name="innerException">
+	/// The exception that is the cause of the current exception, or a null reference if no inner exception is specified.
+	/// </param>
+	public SchedulingException( string message, Exception? innerException ) : base( message, innerException )
+	{
+	}
+
+	#endregion
+}

--- a/src/PiWeb.Sdk.Import/Import/ImportController/Exceptions/SchedulingNotSupportedException.cs
+++ b/src/PiWeb.Sdk.Import/Import/ImportController/Exceptions/SchedulingNotSupportedException.cs
@@ -1,0 +1,27 @@
+﻿#region copyright
+
+/* * * * * * * * * * * * * * * * * * * * * * * * * */
+/* Carl Zeiss Industrielle Messtechnik GmbH        */
+/* Softwaresystem PiWeb                            */
+/* (c) Carl Zeiss 2023                             */
+/* * * * * * * * * * * * * * * * * * * * * * * * * */
+
+#endregion
+
+namespace Zeiss.PiWeb.Sdk.Import.ImportController.Exceptions;
+
+/// <summary>
+/// Represents an error where rescheduling of an import file fails be rescheduling is not supported.
+/// </summary>
+public sealed class SchedulingNotSupportedException : SchedulingException
+{
+	#region constructors
+
+	/// <summary>
+	/// Initializes a new instance of the <see cref="SchedulingNotSupportedException"/> class.
+	/// </summary>
+	public SchedulingNotSupportedException() : base( "Scheduling is not supported." )
+	{ }
+
+	#endregion
+}

--- a/src/PiWeb.Sdk.Import/Import/ImportController/IImportController.cs
+++ b/src/PiWeb.Sdk.Import/Import/ImportController/IImportController.cs
@@ -1,0 +1,57 @@
+#region copyright
+
+/* * * * * * * * * * * * * * * * * * * * * * * * * */
+/* Carl Zeiss Industrielle Messtechnik GmbH        */
+/* Softwaresystem PiWeb                            */
+/* (c) Carl Zeiss 2024                             */
+/* * * * * * * * * * * * * * * * * * * * * * * * * */
+
+#endregion
+
+using System.Collections.Generic;
+using Zeiss.PiWeb.Sdk.Import.ImportController.Exceptions;
+using Zeiss.PiWeb.Sdk.Import.ImportFiles;
+
+namespace Zeiss.PiWeb.Sdk.Import.ImportController;
+
+/// <summary>
+/// Responsible for controlling the import pipeline. Provides methods to modify the behavior of the
+/// import process.
+/// </summary>
+public interface IImportController
+{
+    /// <summary>
+    /// Indicates whether rescheduling of import files is supported.
+    /// Rescheduling will not be available in all contexts. For example rescheduling is typically not supported
+    /// if import files are imported interactively. This property should always be checked before using
+    /// <see cref="RescheduleImportFiles"/>. If a file needs to be scheduled, but the operation is not supported, an
+    /// import error should be raised. 
+    /// </summary>
+    bool CanRescheduleImportFiles { get; }
+
+    /// <summary>
+    /// Schedules the given import files to being added back into the queue of unprocessed import files after a
+    /// wait time. The default wait time is predetermined by the hosting application and may vary on the number
+    /// of times an import file was rescheduled previously.
+    /// After the import files are added back to the import queue, they will be picked up again by import file grouping
+    /// and thus will be processed once more as import.
+    /// Only import files of the currently active import group may be rescheduled.
+    /// Rescheduling of one or more import files does not remove these files from their current import group.
+    /// They will be processed as normal except for not being backed up or deleted at the end.
+    /// This is useful to process import files again when for any reason the first processing could not import it
+    /// completely or at all.
+    /// Rescheduling will not be available in all contexts. For example rescheduling is typically not supported
+    /// if import files are imported interactively. Always check <see cref="CanRescheduleImportFiles"/> first.
+    /// </summary>
+    /// <param name="files">
+    /// The import files to reschedule.
+    /// </param>
+    /// <exception cref="SchedulingException">
+    /// Thrown when any of the given import files cannot be rescheduled.
+    /// </exception>
+    /// <exception cref="SchedulingNotSupportedException">Thrown when rescheduling is not supported.</exception>
+    /// <exception cref="ImportControllerException">
+    /// Thrown when this import controller is used after the import it belongs to is already finished.
+    /// </exception> 
+    SchedulingResult RescheduleImportFiles(IEnumerable<IImportFile> files);
+}

--- a/src/PiWeb.Sdk.Import/Import/ImportController/SchedulingResult.cs
+++ b/src/PiWeb.Sdk.Import/Import/ImportController/SchedulingResult.cs
@@ -1,0 +1,25 @@
+#region copyright
+
+/* * * * * * * * * * * * * * * * * * * * * * * * * */
+/* Carl Zeiss Industrielle Messtechnik GmbH        */
+/* Softwaresystem PiWeb                            */
+/* (c) Carl Zeiss 2023                             */
+/* * * * * * * * * * * * * * * * * * * * * * * * * */
+
+#endregion
+
+using System;
+
+namespace Zeiss.PiWeb.Sdk.Import.ImportController;
+
+/// <summary>
+/// Represents the result of a scheduling operation.
+/// </summary>
+public class SchedulingResult
+{
+    /// <summary>
+    /// Indicates the date and time the scheduled file will be added back to the import queue if this information
+    /// is available. Otherwise, this property is null.
+    /// </summary>
+    public DateTimeOffset? DueTime { get; init; }
+}

--- a/src/PiWeb.Sdk.Import/Import/ImportFiles/IImportFile.cs
+++ b/src/PiWeb.Sdk.Import/Import/ImportFiles/IImportFile.cs
@@ -10,6 +10,7 @@
 
 using System;
 using System.IO;
+using Zeiss.PiWeb.Sdk.Import.ImportController;
 using Zeiss.PiWeb.Sdk.Import.ImportFiles.Exceptions;
 
 namespace Zeiss.PiWeb.Sdk.Import.ImportFiles;
@@ -51,6 +52,23 @@ public interface IImportFile
     /// </summary>
     DateTimeOffset? CreationTime { get; }
     
+    /// <summary>
+    /// The time this file was discovered or null when this information is not available.
+    /// </summary>
+    DateTimeOffset? DiscoveryTime { get; }
+
+    /// <summary>
+    /// Indicates how many times this import file was added to the import queue. This value will be one when a
+    /// new import file is discovered and is increased by one each time the file is re-queued.
+    /// See <see cref="IImportController.RescheduleImportFiles"/>.
+    /// </summary>
+    long QueueCount { get; }
+
+    /// <summary>
+    /// Can be used to attach custom data to this import file.
+    /// </summary>
+    object? Payload { get; set; }
+
     #endregion
 
     #region methods

--- a/src/PiWeb.Sdk.Import/Import/ImportFiles/IImportGroup.cs
+++ b/src/PiWeb.Sdk.Import/Import/ImportFiles/IImportGroup.cs
@@ -35,6 +35,11 @@ public interface IImportGroup
     IReadOnlyList<IImportFile> AdditionalFiles { get; }
 
     /// <summary>
+    /// Enumerates all import files of this group.
+    /// </summary>
+    IEnumerable<IImportFile> GetAllFiles();
+    
+    /// <summary>
     /// Adds the given import file to this import group. 
     /// </summary>
     void AddFile(IImportFile importFile);

--- a/src/PiWeb.Sdk.Import/Import/ImportHistory/Exceptions/ImportHistoryServiceException.cs
+++ b/src/PiWeb.Sdk.Import/Import/ImportHistory/Exceptions/ImportHistoryServiceException.cs
@@ -1,0 +1,42 @@
+﻿#region copyright
+
+/* * * * * * * * * * * * * * * * * * * * * * * * * */
+/* Carl Zeiss Industrielle Messtechnik GmbH        */
+/* Softwaresystem PiWeb                            */
+/* (c) Carl Zeiss 2023                             */
+/* * * * * * * * * * * * * * * * * * * * * * * * * */
+
+#endregion
+
+using System;
+using Zeiss.PiWeb.Sdk.Common.Exceptions;
+
+namespace Zeiss.PiWeb.Sdk.Import.ImportHistory.Exceptions;
+
+/// <summary>
+/// Represents an error when using an import history service.
+/// </summary>
+public class ImportHistoryServiceException : PluginException
+{
+	#region constructors
+
+	/// <summary>
+	/// Initializes a new instance of the <see cref="ImportHistoryServiceException"/> class.
+	/// </summary>
+	/// <param name="message">The message that describes the error.</param>
+	public ImportHistoryServiceException( string message ) : base( message )
+	{ }
+
+	/// <summary>
+	/// Initializes a new instance of the <see cref="ImportHistoryServiceException"/> class.
+	/// </summary>
+	/// <param name="message">The message that describes the error.</param>
+	/// <param name="innerException">
+	/// The exception that is the cause of the current exception, or a null reference if no inner exception is specified.
+	/// </param>
+	public ImportHistoryServiceException( string message, Exception? innerException ) : base( message, innerException )
+	{
+	}
+
+	#endregion
+}

--- a/src/PiWeb.Sdk.Import/Import/ImportHistory/IImportHistoryService.cs
+++ b/src/PiWeb.Sdk.Import/Import/ImportHistory/IImportHistoryService.cs
@@ -8,13 +8,17 @@
 
 #endregion
 
+using System.Collections.Generic;
+using Zeiss.PiWeb.Sdk.Import.ImportFiles;
+using Zeiss.PiWeb.Sdk.Import.ImportHistory.Exceptions;
+
 namespace Zeiss.PiWeb.Sdk.Import.ImportHistory;
 
 /// <summary>
 /// Responsible for adding log messages to the import history entry of the current import.
 /// The import history is maintained to track successful and faulty imports. Each import creates a new entry in the
 /// import history.
-/// Note: Adding messages with error severity leads to the import being canceled before any data is imported.
+/// Note: Adding messages with error severity will cancel the import after the current step.
 /// </summary>
 public interface IImportHistoryService
 {
@@ -31,5 +35,20 @@ public interface IImportHistoryService
     /// Format arguments used when formatting the display text of message.
     /// </param>
     /// <param name="severity">The severity of the message.</param>
+    /// <exception cref="ImportHistoryServiceException">
+    /// Thrown when this import history service is used after the import it belongs to is already finished.
+    /// </exception>
     public void AddMessage(MessageSeverity severity, string displayText, params object[] formatArgs);
+
+    /// <summary>
+    /// Prevents the specified import files from being included in any import history entries created for
+    /// the current import group. Only import files of the currently active import group may be masked.
+    /// When all import files of the current import group are masked, no import history entries will be written at all.
+    /// </summary>
+    /// <param name="importFiles">The import files to mask.</param>
+    /// <exception cref="ImportHistoryServiceException">
+    /// Thrown when this import history service is used when there is no active import group or after the import it
+    /// belongs to is already finished.
+    /// </exception>
+    public void MaskImportFiles(IEnumerable<IImportFile> importFiles);
 }

--- a/src/PiWeb.Sdk.Import/Import/Modules/ImportFormat/IParseContext.cs
+++ b/src/PiWeb.Sdk.Import/Import/Modules/ImportFormat/IParseContext.cs
@@ -9,6 +9,7 @@
 #endregion
 
 using Zeiss.PiWeb.Sdk.Common.Logging;
+using Zeiss.PiWeb.Sdk.Import.ImportController;
 using Zeiss.PiWeb.Sdk.Import.ImportHistory;
 
 namespace Zeiss.PiWeb.Sdk.Import.Modules.ImportFormat;
@@ -24,6 +25,11 @@ public interface IParseContext
 	/// A service to edit the import history entry of the current import. 
 	/// </summary>
 	IImportHistoryService ImportHistoryService { get; }
+
+	/// <summary>
+	/// The import controller. Can be used to modify the behavior of the current import.
+	/// </summary>
+	IImportController ImportController { get; }
 
 	/// <summary>
 	/// A logger that can be used to write log entries. Written entries are usually forwarded to the log file

--- a/src/PiWeb.Sdk.Import/PiWeb.Sdk.Import.csproj
+++ b/src/PiWeb.Sdk.Import/PiWeb.Sdk.Import.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>net8.0</TargetFramework>
+    <TargetFramework>net10.0</TargetFramework>
     <Nullable>enable</Nullable>
     <AssemblyName>Zeiss.PiWeb.Sdk.Import</AssemblyName>
     <RootNamespace>Zeiss.PiWeb.Sdk</RootNamespace>


### PR DESCRIPTION
Adds the possibility to the import sdk to requeue import files to be processed again. This will allow to come back to files that could not be imported when tried the first time because something was missing. For example, in connection with the future introduction of custom uploaders, this could be used to import files that update existing measurements. When the measurement to update is not yet in the database, the import file can be requeued for a later attempt.