### PR TITLE
feat: Add a factory for custom import uploaders to import formats

### DIFF
--- a/src/PiWeb.Sdk.Import/Import/ImportController/IImportController.cs
+++ b/src/PiWeb.Sdk.Import/Import/ImportController/IImportController.cs
@@ -43,7 +43,7 @@ public interface IImportController
     /// Rescheduling will not be available in all contexts. For example rescheduling is typically not supported
     /// if import files are imported interactively. Always check <see cref="CanRescheduleImportFiles"/> first.
     /// </summary>
-    /// <param name="files">
+    /// <param name="importFiles">
     /// The import files to reschedule.
     /// </param>
     /// <exception cref="SchedulingException">
@@ -53,5 +53,5 @@ public interface IImportController
     /// <exception cref="ImportControllerException">
     /// Thrown when this import controller is used after the import it belongs to is already finished.
     /// </exception> 
-    SchedulingResult RescheduleImportFiles(IEnumerable<IImportFile> files);
+    SchedulingResult RescheduleImportFiles(IEnumerable<IImportFile> importFiles);
 }

--- a/src/PiWeb.Sdk.Import/Import/ImportData/ImportData.cs
+++ b/src/PiWeb.Sdk.Import/Import/ImportData/ImportData.cs
@@ -30,4 +30,9 @@ public class ImportData
     /// and optionally the path rule configuration.
     /// </summary>
     public InspectionPlanPart RootPart { get; set; }
+    
+    /// <summary>
+    /// Can be used to attach custom data to this import data instance.
+    /// </summary>
+    public object? Payload { get; set; }
 }

--- a/src/PiWeb.Sdk.Import/Import/Modules/ImportFormat/CreateImportRunnerException.cs
+++ b/src/PiWeb.Sdk.Import/Import/Modules/ImportFormat/CreateImportRunnerException.cs
@@ -1,0 +1,48 @@
+﻿#region copyright
+
+/* * * * * * * * * * * * * * * * * * * * * * * * * */
+/* Carl Zeiss Industrielle Messtechnik GmbH        */
+/* Softwaresystem PiWeb                            */
+/* (c) Carl Zeiss 2023                             */
+/* * * * * * * * * * * * * * * * * * * * * * * * * */
+
+#endregion
+
+using System;
+using Zeiss.PiWeb.Sdk.Common.Exceptions;
+
+namespace Zeiss.PiWeb.Sdk.Import.Modules.ImportFormat;
+
+/// <summary>
+/// Represents an error during import data upload.
+/// </summary>
+public class UploadException : PluginException
+{
+	#region constructors
+
+	/// <summary>
+	/// Initializes a new instance of the <see cref="UploadException"/> class.
+	/// </summary>
+	public UploadException()
+	{ }
+
+	/// <summary>
+	/// Initializes a new instance of the <see cref="UploadException"/> class.
+	/// </summary>
+	/// <param name="message">The message that describes the error.</param>
+	public UploadException( string message ) : base( message )
+	{ }
+
+	/// <summary>
+	/// Initializes a new instance of the <see cref="UploadException"/> class.
+	/// </summary>
+	/// <param name="message">The message that describes the error.</param>
+	/// <param name="innerException">
+	/// The exception that is the cause of the current exception, or a null reference if no inner exception
+	/// is specified.
+	/// </param>
+	public UploadException( string message, Exception? innerException ) : base( message, innerException )
+	{ }
+
+	#endregion
+}

--- a/src/PiWeb.Sdk.Import/Import/Modules/ImportFormat/ICreateImportUploaderContext.cs
+++ b/src/PiWeb.Sdk.Import/Import/Modules/ImportFormat/ICreateImportUploaderContext.cs
@@ -1,0 +1,42 @@
+#region copyright
+
+/* * * * * * * * * * * * * * * * * * * * * * * * * */
+/* Carl Zeiss Industrielle Messtechnik GmbH        */
+/* Softwaresystem PiWeb                            */
+/* (c) Carl Zeiss 2026                             */
+/* * * * * * * * * * * * * * * * * * * * * * * * * */
+
+#endregion
+
+using System;
+using Zeiss.PiWeb.Sdk.Common.Logging;
+using Zeiss.PiWeb.Sdk.Import.ImportPlan;
+
+namespace Zeiss.PiWeb.Sdk.Import.Modules.ImportFormat;
+
+/// <summary>
+/// Represents the context for the creation of <see cref="IImportUploader"/> instances. This context will be
+/// provided by the hosting application.
+/// </summary>
+public interface ICreateCustomImportUploaderContext
+{
+    #region properties
+
+    /// <summary>
+    /// The configured import target.
+    /// </summary>
+    ImportTarget ImportTarget { get; }
+	
+    /// <summary>
+    /// The id of the currently executing import plan.
+    /// </summary>
+    Guid ImportPlanId { get; }
+    
+    /// <summary>
+    /// A logger that can be used to write log entries. Written entries are usually forwarded to the log file of the
+    /// hosting application.
+    /// </summary>
+    ILogger Logger { get; }
+
+    #endregion
+}

--- a/src/PiWeb.Sdk.Import/Import/Modules/ImportFormat/IImportFormat.cs
+++ b/src/PiWeb.Sdk.Import/Import/Modules/ImportFormat/IImportFormat.cs
@@ -14,7 +14,7 @@ namespace Zeiss.PiWeb.Sdk.Import.Modules.ImportFormat;
 
 /// <summary>
 /// Represents a custom import format provided as part of a plugin. Custom import formats provide a way to identify and group relevant
-/// files, parse their data and create a data image that can be uploaded to PiWeb Server.
+/// files, parse their data and create a data image that can be uploaded to a PiWeb database.
 /// </summary>
 public interface IImportFormat
 {
@@ -46,6 +46,18 @@ public interface IImportFormat
     /// <param name="context">Provides context information.</param>
     /// <returns>The created import parser.</returns>
     IImportParser CreateImportParser(ICreateImportParserContext context);
+
+    /// <summary>
+    /// Creates a custom import uploader associated with this import format. The import uploader is responsible for
+    /// transferring parsed data created by the import parser to the PiWeb Server.
+    /// If this method returns <c>null</c>, a build in standard uploader is used instead.   
+    /// </summary>
+    /// <param name="context">Provides context information.</param>
+    /// <returns>The created import uploader.</returns>
+    IImportUploader? CreateCustomImportUploader(ICreateCustomImportUploaderContext context)
+    {
+        return null;
+    }
 
     #endregion
 }

--- a/src/PiWeb.Sdk.Import/Import/Modules/ImportFormat/IImportUploader.cs
+++ b/src/PiWeb.Sdk.Import/Import/Modules/ImportFormat/IImportUploader.cs
@@ -1,0 +1,41 @@
+#region copyright
+
+/* * * * * * * * * * * * * * * * * * * * * * * * * */
+/* Carl Zeiss Industrielle Messtechnik GmbH        */
+/* Softwaresystem PiWeb                            */
+/* (c) Carl Zeiss 2024                             */
+/* * * * * * * * * * * * * * * * * * * * * * * * * */
+
+#endregion
+
+using System;
+using System.Threading;
+using System.Threading.Tasks;
+using Zeiss.PiWeb.Sdk.Import.ImportData;
+
+namespace Zeiss.PiWeb.Sdk.Import.Modules.ImportFormat;
+
+/// <summary>
+/// Responsible for uploading parse results to the PiWeb database. An Import format may provide a custom
+/// import uploader implementation or opt to use the built-in default import uploader. Import formats usually
+/// use the default import uploader. Custom import uploaders are only necessary in very specific cases.  
+/// </summary>
+/// <exception cref="OperationCanceledException">Thrown when the operation is canceled.</exception>
+public interface IImportUploader
+{
+	/// <summary>
+	/// Uploads the given import data to the PiWeb database.
+	/// </summary>
+	/// <param name="importData">The import data to upload.</param>
+	/// <param name="context">Provides information about the import context.</param>
+	/// <param name="cancellationToken">A cancellation token to signal cancellation of the import.</param>
+	/// <returns>
+	/// The result of the upload. This includes information about the number of operations on entities and the path
+	/// of the part this upload should be associated with.
+	/// </returns>
+	/// <exception cref="UploadException">Thrown when the data upload fails.</exception>
+	Task<UploadResult> UploadAsync(
+		ImportData.ImportData importData,
+		IUploadContext context,
+		CancellationToken cancellationToken = default);
+}

--- a/src/PiWeb.Sdk.Import/Import/Modules/ImportFormat/IUploadContext.cs
+++ b/src/PiWeb.Sdk.Import/Import/Modules/ImportFormat/IUploadContext.cs
@@ -1,0 +1,60 @@
+﻿#region copyright
+
+/* * * * * * * * * * * * * * * * * * * * * * * * * */
+/* Carl Zeiss Industrielle Messtechnik GmbH        */
+/* Softwaresystem PiWeb                            */
+/* (c) Carl Zeiss 2024                             */
+/* * * * * * * * * * * * * * * * * * * * * * * * * */
+
+#endregion
+
+using Zeiss.PiWeb.Sdk.Common.Logging;
+using Zeiss.PiWeb.Sdk.Import.ImportController;
+using Zeiss.PiWeb.Sdk.Import.ImportFiles;
+using Zeiss.PiWeb.Sdk.Import.ImportHistory;
+
+namespace Zeiss.PiWeb.Sdk.Import.Modules.ImportFormat;
+
+/// <summary>
+/// Represents the context of an import runner provided by the hosting application.
+/// </summary>
+public interface IUploadContext
+{
+	#region properties
+
+	/// <summary>
+	/// A service to edit the import history entry of the current import. 
+	/// </summary>
+	IImportHistoryService ImportHistoryService { get; }
+
+	/// <summary>
+	/// The import controller. Can be used to modify the behavior of the current import.
+	/// </summary>
+	IImportController ImportController { get; }
+
+	/// <summary>
+	/// The import group of the current import.
+	/// </summary>
+	IImportGroup ImportGroup { get; }
+
+	/// <summary>
+	/// The path of the part this upload was originally targeted at in RoundtripString format.
+	/// This path is directly determined by the import source.
+	/// </summary>
+	string OriginalImportTargetPartPath { get; }
+	
+	/// <summary>
+	/// The path of the part this upload is finally targeted at in RoundtripString format.
+	/// This path is created by applying the configured path rules to the original import target part path or
+	/// the root path. 
+	/// </summary>
+	string ImportTargetPartPath { get; }
+
+	/// <summary>
+	/// A logger that can be used to write log entries. Written entries are usually forwarded to the log file
+	/// of the hosting application.
+	/// </summary>
+	ILogger Logger { get; }
+
+	#endregion
+}

--- a/src/PiWeb.Sdk.Import/Import/Modules/ImportFormat/UploadMetrics.cs
+++ b/src/PiWeb.Sdk.Import/Import/Modules/ImportFormat/UploadMetrics.cs
@@ -1,0 +1,47 @@
+#region copyright
+
+/* * * * * * * * * * * * * * * * * * * * * * * * * */
+/* Carl Zeiss Industrielle Messtechnik GmbH        */
+/* Softwaresystem PiWeb                            */
+/* (c) Carl Zeiss 2026                             */
+/* * * * * * * * * * * * * * * * * * * * * * * * * */
+
+#endregion
+
+namespace Zeiss.PiWeb.Sdk.Import.Modules.ImportFormat;
+
+/// <summary>
+///     Represents information about the number of various operations made during upload.
+/// </summary>
+public record class UploadMetrics
+{
+    /// <summary>
+    /// The number of entities created by the upload.
+    /// </summary>
+    public uint Created { get; set; }
+
+    /// <summary>
+    /// The number of entities updated by the upload.
+    /// </summary>
+    public uint Updated { get; set; }
+
+    /// <summary>
+    /// The number of entities deleted by the upload.
+    /// </summary>
+    public uint Deleted { get; set; }
+
+    /// <summary>
+    /// The number of additional data items created by the upload.
+    /// </summary>
+    public uint AdditionalDataItemsCreated { get; set; }
+
+    /// <summary>
+    /// The number of additional data items updated by the upload.
+    /// </summary>
+    public uint AdditionalDataItemsUpdated { get; set; }
+
+    /// <summary>
+    /// The number of additional data items deleted by the upload.
+    /// </summary>
+    public uint AdditionalDataItemsDeleted { get; set; }
+}

--- a/src/PiWeb.Sdk.Import/Import/Modules/ImportFormat/UploadResult.cs
+++ b/src/PiWeb.Sdk.Import/Import/Modules/ImportFormat/UploadResult.cs
@@ -1,0 +1,49 @@
+﻿#region copyright
+
+/* * * * * * * * * * * * * * * * * * * * * * * * * */
+/* Carl Zeiss Industrielle Messtechnik GmbH        */
+/* Softwaresystem PiWeb                            */
+/* (c) Carl Zeiss 2026                             */
+/* * * * * * * * * * * * * * * * * * * * * * * * * */
+
+#endregion
+
+namespace Zeiss.PiWeb.Sdk.Import.Modules.ImportFormat;
+
+/// <summary>
+/// Represents the result of a data upload.
+/// </summary>
+public class UploadResult
+{
+    /// <summary>
+    /// The path of the domain part in RoundtripString format. This should be the most specific part that envelops
+    /// all changes to the PiWeb database made by the upload. Import history entries of this upload will be attached to
+    /// this part.
+    /// If this is empty or not a valid part path, the import target part will be used as domain part.  
+    /// </summary>
+    public string DomainPartPath { get; set; } = string.Empty;
+
+    /// <summary>
+    /// Information about the number of various operations on parts made during the upload. This information is
+    /// used to create history entries for the import.
+    /// </summary>
+    public UploadMetrics PartMetrics { get; set; } = new UploadMetrics();
+
+    /// <summary>
+    /// Information about the number of various operations on characteristics made during the upload. This information
+    /// is used to create history entries for the import.
+    /// </summary>
+    public UploadMetrics CharacteristicMetrics { get; set; } = new UploadMetrics();
+
+    /// <summary>
+    /// Information about the number of various operations on measurements made during the upload. This information is
+    /// used to create history entries for the import.
+    /// </summary>
+    public UploadMetrics MeasurementMetrics { get; set; } = new UploadMetrics();
+
+    /// <summary>
+    /// Information about the number of various operations on measured values made during the upload. This information
+    /// is used to create history entries for the import.
+    /// </summary>
+    public UploadMetrics ValueMetrics { get; set; } = new UploadMetrics();
+}


### PR DESCRIPTION
Using custom import uploaders, it is possible to write custom upload code when the built-in import uploader is insufficient. The idea is very similar to how import automations work: Connection information and authentication data are passed as context which can then be used to initialize the PiWeb API. The actual data upload is then implemented using the PiWeb API. There is also one small improvement:
- ImportData now provides a user writable payload property which can be used to transfer additional data between parser and uploader.