### PR TITLE
refactor: Introduce scheduling settings to control import history behavior when rescheduling

### DIFF
--- a/src/PiWeb.Sdk.Import/Import/ImportController/Exceptions/ImportControllerException.cs
+++ b/src/PiWeb.Sdk.Import/Import/ImportController/Exceptions/ImportControllerException.cs
@@ -3,7 +3,7 @@
 /* * * * * * * * * * * * * * * * * * * * * * * * * */
 /* Carl Zeiss Industrielle Messtechnik GmbH        */
 /* Softwaresystem PiWeb                            */
-/* (c) Carl Zeiss 2023                             */
+/* (c) Carl Zeiss 2026                             */
 /* * * * * * * * * * * * * * * * * * * * * * * * * */
 
 #endregion

--- a/src/PiWeb.Sdk.Import/Import/ImportController/Exceptions/SchedulingException.cs
+++ b/src/PiWeb.Sdk.Import/Import/ImportController/Exceptions/SchedulingException.cs
@@ -3,7 +3,7 @@
 /* * * * * * * * * * * * * * * * * * * * * * * * * */
 /* Carl Zeiss Industrielle Messtechnik GmbH        */
 /* Softwaresystem PiWeb                            */
-/* (c) Carl Zeiss 2023                             */
+/* (c) Carl Zeiss 2026                             */
 /* * * * * * * * * * * * * * * * * * * * * * * * * */
 
 #endregion

--- a/src/PiWeb.Sdk.Import/Import/ImportController/Exceptions/SchedulingNotSupportedException.cs
+++ b/src/PiWeb.Sdk.Import/Import/ImportController/Exceptions/SchedulingNotSupportedException.cs
@@ -3,7 +3,7 @@
 /* * * * * * * * * * * * * * * * * * * * * * * * * */
 /* Carl Zeiss Industrielle Messtechnik GmbH        */
 /* Softwaresystem PiWeb                            */
-/* (c) Carl Zeiss 2023                             */
+/* (c) Carl Zeiss 2026                             */
 /* * * * * * * * * * * * * * * * * * * * * * * * * */
 
 #endregion

--- a/src/PiWeb.Sdk.Import/Import/ImportController/IImportController.cs
+++ b/src/PiWeb.Sdk.Import/Import/ImportController/IImportController.cs
@@ -3,7 +3,7 @@
 /* * * * * * * * * * * * * * * * * * * * * * * * * */
 /* Carl Zeiss Industrielle Messtechnik GmbH        */
 /* Softwaresystem PiWeb                            */
-/* (c) Carl Zeiss 2024                             */
+/* (c) Carl Zeiss 2026                             */
 /* * * * * * * * * * * * * * * * * * * * * * * * * */
 
 #endregion
@@ -24,25 +24,30 @@ public interface IImportController
     /// Indicates whether rescheduling of import files is supported.
     /// Rescheduling will not be available in all contexts. For example rescheduling is typically not supported
     /// if import files are imported interactively. This property should always be checked before using
-    /// <see cref="RescheduleImportFiles"/>. If a file needs to be scheduled, but the operation is not supported, an
-    /// import error should be raised. 
+    /// <see cref="RescheduleImportFiles(System.Collections.Generic.IEnumerable{Zeiss.PiWeb.Sdk.Import.ImportFiles.IImportFile})" />.
+    /// If a file needs to be scheduled, but the operation is not supported, an
+    /// import error should be raised.
     /// </summary>
     bool CanRescheduleImportFiles { get; }
 
     /// <summary>
-    /// Schedules the given import files to being added back into the queue of unprocessed import files after a
-    /// wait time. The default wait time is predetermined by the hosting application and may vary on the number
-    /// of times an import file was rescheduled previously.
-    /// After the import files are added back to the import queue, they will be picked up again by import file grouping
-    /// and thus will be processed once more as import.
+    /// Schedules the given import files to be added back into the queue of unprocessed import files. The given import
+    /// files will not be added back immediately but after a hosting application specific wait time (which may also
+    /// depend on previous rescheduling operations). During this wait time the given files will not be considered for
+    /// import. Afterwarts the files are available again and will be treated as new import files.
+    /// Rescheduling of one or more import files does not remove these files from their current import group,
+    /// but after the current import finishes, import files will be kept in the import folder (without file backup).
+    /// Rescheduled files will not be mentioned in the import history entries of the current import. If all files
+    /// of the current import group are rescheduled, no import history entry for the current import is created at all.
     /// Only import files of the currently active import group may be rescheduled.
-    /// Rescheduling of one or more import files does not remove these files from their current import group.
-    /// They will be processed as normal except for not being backed up or deleted at the end.
-    /// This is useful to process import files again when for any reason the first processing could not import it
-    /// completely or at all.
-    /// Rescheduling will not be available in all contexts. For example rescheduling is typically not supported
-    /// if import files are imported interactively. Always check <see cref="CanRescheduleImportFiles"/> first.
+    /// Note: Rescheduling will not be available in all contexts. For example rescheduling is typically not supported
+    /// if import files are imported interactively. Always check <see cref="CanRescheduleImportFiles" /> first.
     /// </summary>
+    /// <remarks>
+    /// This method is useful when an import file cannot be imported at the current point in time because some
+    /// external information (e.g. an already existing measurement) is missing. Rescheduling the import
+    /// file will retry the import at a later point in time.
+    /// </remarks>
     /// <param name="importFiles">
     /// The import files to reschedule.
     /// </param>
@@ -52,6 +57,39 @@ public interface IImportController
     /// <exception cref="SchedulingNotSupportedException">Thrown when rescheduling is not supported.</exception>
     /// <exception cref="ImportControllerException">
     /// Thrown when this import controller is used after the import it belongs to is already finished.
-    /// </exception> 
+    /// </exception>
     SchedulingResult RescheduleImportFiles(IEnumerable<IImportFile> importFiles);
+    
+    /// <summary>
+    /// Schedules the given import files to be added back into the queue of unprocessed import files. The given import
+    /// files will not be added back immediately but after a hosting application specific wait time (which may also
+    /// depend on previous rescheduling operations). During this wait time the given files will not be considered for
+    /// import. Afterwarts the files are available again and will be treated as new import files.
+    /// Rescheduling of one or more import files does not remove these files from their current import group,
+    /// but after the current import finishes, import files will be kept in the import folder (without file backup).
+    /// The construction of the import history entry of the current import can be specified using the
+    /// <paramref name="schedulingSettings"/> parameter.   
+    /// Only import files of the currently active import group may be rescheduled.
+    /// Note: Rescheduling will not be available in all contexts. For example rescheduling is typically not supported
+    /// if import files are imported interactively. Always check <see cref="CanRescheduleImportFiles" /> first.
+    /// </summary>
+    /// <remarks>
+    /// This method is useful when an import file cannot be imported at the current point in time because some
+    /// external information (e.g. an already existing measurement) is missing. Rescheduling the import
+    /// file will retry the import at a later point in time. Using the <paramref name="schedulingSettings"/> parameter,
+    /// it is possible to specify whether each import attempt results in an import history entry or only the last
+    /// attempt.
+    /// </remarks>
+    /// <param name="importFiles">
+    /// The import files to reschedule.
+    /// </param>
+    /// <param name="schedulingSettings"></param>
+    /// <exception cref="SchedulingException">
+    /// Thrown when any of the given import files cannot be rescheduled.
+    /// </exception>
+    /// <exception cref="SchedulingNotSupportedException">Thrown when rescheduling is not supported.</exception>
+    /// <exception cref="ImportControllerException">
+    /// Thrown when this import controller is used after the import it belongs to is already finished.
+    /// </exception>
+    SchedulingResult RescheduleImportFiles(IEnumerable<IImportFile> importFiles, SchedulingSettings schedulingSettings);
 }

--- a/src/PiWeb.Sdk.Import/Import/ImportController/SchedulingResult.cs
+++ b/src/PiWeb.Sdk.Import/Import/ImportController/SchedulingResult.cs
@@ -3,7 +3,7 @@
 /* * * * * * * * * * * * * * * * * * * * * * * * * */
 /* Carl Zeiss Industrielle Messtechnik GmbH        */
 /* Softwaresystem PiWeb                            */
-/* (c) Carl Zeiss 2023                             */
+/* (c) Carl Zeiss 2026                             */
 /* * * * * * * * * * * * * * * * * * * * * * * * * */
 
 #endregion

--- a/src/PiWeb.Sdk.Import/Import/ImportController/SchedulingSettings.cs
+++ b/src/PiWeb.Sdk.Import/Import/ImportController/SchedulingSettings.cs
@@ -1,0 +1,24 @@
+#region copyright
+
+/* * * * * * * * * * * * * * * * * * * * * * * * * */
+/* Carl Zeiss Industrielle Messtechnik GmbH        */
+/* Softwaresystem PiWeb                            */
+/* (c) Carl Zeiss 2026                             */
+/* * * * * * * * * * * * * * * * * * * * * * * * * */
+
+#endregion
+
+namespace Zeiss.PiWeb.Sdk.Import.ImportController;
+
+/// <summary>
+/// Additional settings to determine the behavior of scheduling operations.
+/// </summary>
+public record SchedulingSettings
+{
+    /// <summary>
+    /// Specifies whether the rescheduled files should still be reported in the import history entry of the
+    /// current import. If none of the import files of the current import group is left to be reported in the import
+    /// history, no import history entry for the current import will be created at all. 
+    /// </summary>
+    public bool ReportInCurrentImportHistory { get; set; } = false;
+}

--- a/src/PiWeb.Sdk.Import/Import/ImportFiles/IImportFile.cs
+++ b/src/PiWeb.Sdk.Import/Import/ImportFiles/IImportFile.cs
@@ -60,7 +60,7 @@ public interface IImportFile
     /// <summary>
     /// Indicates how many times this import file was added to the import queue. This value will be one when a
     /// new import file is discovered and is increased by one each time the file is re-queued.
-    /// See <see cref="IImportController.RescheduleImportFiles"/>.
+    /// See <see cref="IImportController.RescheduleImportFiles(System.Collections.Generic.IEnumerable{Zeiss.PiWeb.Sdk.Import.ImportFiles.IImportFile})"/>.
     /// </summary>
     long QueueCount { get; }
 

--- a/src/PiWeb.Sdk.Import/Import/ImportHistory/IImportHistoryService.cs
+++ b/src/PiWeb.Sdk.Import/Import/ImportHistory/IImportHistoryService.cs
@@ -8,8 +8,6 @@
 
 #endregion
 
-using System.Collections.Generic;
-using Zeiss.PiWeb.Sdk.Import.ImportFiles;
 using Zeiss.PiWeb.Sdk.Import.ImportHistory.Exceptions;
 
 namespace Zeiss.PiWeb.Sdk.Import.ImportHistory;
@@ -39,16 +37,4 @@ public interface IImportHistoryService
     /// Thrown when this import history service is used after the import it belongs to is already finished.
     /// </exception>
     public void AddMessage(MessageSeverity severity, string displayText, params object[] formatArgs);
-
-    /// <summary>
-    /// Prevents the specified import files from being included in any import history entries created for
-    /// the current import group. Only import files of the currently active import group may be masked.
-    /// When all import files of the current import group are masked, no import history entries will be written at all.
-    /// </summary>
-    /// <param name="importFiles">The import files to mask.</param>
-    /// <exception cref="ImportHistoryServiceException">
-    /// Thrown when this import history service is used when there is no active import group or after the import it
-    /// belongs to is already finished.
-    /// </exception>
-    public void MaskImportFiles(IEnumerable<IImportFile> importFiles);
 }


### PR DESCRIPTION
Using scheduling settings instead of separate calls on various services to control this behavior allows for better extensibility and better documentation.