### PR TITLE
feat: Extend the project template to include the selection of the import SDK version

### DIFF
--- a/templates/Zeiss.PiWeb.Sdk.Import.ProjectTemplates.csproj
+++ b/templates/Zeiss.PiWeb.Sdk.Import.ProjectTemplates.csproj
@@ -5,6 +5,7 @@
     <TargetFramework>netstandard2.0</TargetFramework>
     <PackageId>Zeiss.PiWeb.Sdk.Import.ProjectTemplates</PackageId>
     <Title>PiWeb-Import-Sdk Project Templates</Title>
+    <Version>1.1.0</Version>
     <Company>Carl Zeiss Industrielle Messtechnik GmbH</Company>
     <Authors>$(Company)</Authors>
     <Copyright>Copyright © $([System.DateTime]::UtcNow.Year) $(Company)</Copyright>
@@ -15,7 +16,7 @@
     <PackageProjectUrl>https://github.com/ZEISS-PiWeb/PiWeb-Import-Sdk</PackageProjectUrl>
     <RepositoryUrl>https://github.com/ZEISS-PiWeb/PiWeb-Import-Sdk.git</RepositoryUrl>
     <RepositoryType>git</RepositoryType>
-    <PackageOutputPath>$(MSBuildThisFileDirectory)\</PackageOutputPath>
+    <PackageOutputPath>$(MSBuildThisFileDirectory)</PackageOutputPath>
     <IncludeContentInPack>true</IncludeContentInPack>
     <IncludeBuildOutput>false</IncludeBuildOutput>
     <ContentTargetFolders>content</ContentTargetFolders>

--- a/templates/content/Zeiss.PiWeb.Sdk.Import.PluginProject/.template.config/template.json
+++ b/templates/content/Zeiss.PiWeb.Sdk.Import.PluginProject/.template.config/template.json
@@ -13,6 +13,25 @@
   "sourceName": "Zeiss.PiWeb.Sdk.Import.PluginProject",
   "preferNameDirectory" : true,
   "symbols":{
+    "ImportSdkVersion": {
+      "type": "parameter",
+      "datatype": "choice",
+      "description": "The import SDK version.",
+      "displayName": "Import SDK version",
+      "defaultValue": "1.1",
+      "choices": [
+        {
+          "choice": "1.0",
+          "displayName": "1.0 (at least PiWeb 2025.R1)",
+          "description": "Use Import SDK version 1.0 (requires at least PiWeb 2025.R1)"
+        },
+        {
+          "choice": "1.1",
+          "displayName": "1.1 (at least PiWeb 2026.R2)",
+          "description": "Use Import SDK version 1.1 (requires at least PiWeb 2026.R2)"
+        }
+      ]
+    },
     "PluginType": {
       "type": "parameter",
       "datatype": "choice",

--- a/templates/content/Zeiss.PiWeb.Sdk.Import.PluginProject/Zeiss.PiWeb.Sdk.Import.PluginProject.csproj
+++ b/templates/content/Zeiss.PiWeb.Sdk.Import.PluginProject/Zeiss.PiWeb.Sdk.Import.PluginProject.csproj
@@ -1,14 +1,16 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>net8.0</TargetFramework>
+    <TargetFramework Condition="'$(ImportSdkVersion)' == '1.0'">net8.0</TargetFramework>
+    <TargetFramework Condition="'$(ImportSdkVersion)' == '1.1'">net10.0</TargetFramework>
     <Nullable>enable</Nullable>
     <EnableDynamicLoading>true</EnableDynamicLoading>
     <GeneratePluginPackageOnBuild>true</GeneratePluginPackageOnBuild>
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Zeiss.PiWeb.Sdk.Import" Version="1.0.0" Private="false" ExcludeAssets="runtime" />
+    <PackageReference Condition="'$(ImportSdkVersion)' == '1.0'" Include="Zeiss.PiWeb.Sdk.Import" Version="1.0.0" Private="false" ExcludeAssets="runtime" />
+    <PackageReference Condition="'$(ImportSdkVersion)' == '1.1'" Include="Zeiss.PiWeb.Sdk.Import" Version="1.1.0" Private="false" ExcludeAssets="runtime" />
   </ItemGroup>
 
   <ItemGroup>


### PR DESCRIPTION
This PR updates the `dotnet new` project template to include a selection for picking the `Import SDK version`.

<img width="578" height="232" alt="image" src="https://github.com/user-attachments/assets/8aa77861-c3ca-46cf-8edf-161fbb1bec02" />
